### PR TITLE
Bring GNO-style retrieval workflow into Codegraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ codegraph search "parse config" --min-score 0.4 -n 10
 codegraph search "parseConfig" --mode keyword   # BM25 keyword-only (exact names)
 codegraph search "auth flow" --mode semantic    # Embedding-only (conceptual)
 codegraph search "auth flow" --mode hybrid      # BM25 + semantic RRF fusion (default)
-codegraph search "auth flow" --expand --explain # Expansion + source metadata
+codegraph search "auth" --query-mode term:auth --query-mode intent:"validate bearer token" # Explicit routed variants
 codegraph models               # List available models
 ```
 

--- a/README.md
+++ b/README.md
@@ -395,10 +395,10 @@ codegraph cycles --functions   # Function-level cycles
 
 ### Semantic Search
 
-Local embeddings for every function, method, and class — search by natural language. The default embedding model is `nomic-v1.5`; optional GGUF and HTTP embedding backends are documented in the [retrieval workflow guide](docs/guides/retrieval-workflow.md).
+Local embeddings for every function, method, and class — search by natural language. The default retrieval preset is `gno-compact` with the Qwen compact GGUF embedding role; legacy transformer aliases and HTTP embedding backends are documented in the [retrieval workflow guide](docs/guides/retrieval-workflow.md).
 
 ```bash
-codegraph embed                # Build embeddings (default: nomic-v1.5)
+codegraph embed                # Build embeddings (default: GNO/Qwen compact GGUF)
 codegraph embed --model nomic  # Use a different model
 codegraph search "handle authentication"
 codegraph search "parse config" --min-score 0.4 -n 10
@@ -433,10 +433,10 @@ A single trailing semicolon is ignored (falls back to single-query mode). The `-
 | `jina-base` | jina-embeddings-v2-base-en | 768 | ~137 MB | Apache-2.0 | High quality, 8192 token context |
 | `jina-code` | jina-embeddings-v2-base-code | 768 | ~137 MB | Apache-2.0 | Best for code search, trained on code+text (requires HF token) |
 | `nomic` | nomic-embed-text-v1 | 768 | ~137 MB | Apache-2.0 | Good quality, 8192 context |
-| `nomic-v1.5` (default) | nomic-embed-text-v1.5 | 768 | ~137 MB | Apache-2.0 | **Improved nomic, Matryoshka dimensions** |
+| `nomic-v1.5` | nomic-embed-text-v1.5 | 768 | ~137 MB | Apache-2.0 | **Improved nomic, Matryoshka dimensions; legacy default** |
 | `bge-large` | bge-large-en-v1.5 | 1024 | ~335 MB | MIT | Best general retrieval, top MTEB scores |
 
-The model used during `embed` is stored in the database, so `search` auto-detects it — no need to pass `--model` when searching.
+Default embedding role: `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf`. The model used during `embed` is stored in the database, so `search` auto-detects it — no need to pass `--model` when searching. Existing configs that set `embeddings.model` (for example `nomic-v1.5`) continue to override the default; use `models.preset: "codegraph-default"` to keep the legacy compatibility preset.
 
 ### Multi-Repo Registry
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ codegraph cycles --functions   # Function-level cycles
 
 ### Semantic Search
 
-Local embeddings for every function, method, and class — search by natural language. Everything runs locally using [@huggingface/transformers](https://huggingface.co/docs/transformers.js) — no API keys needed.
+Local embeddings for every function, method, and class — search by natural language. The default embedding model is `nomic-v1.5`; optional GGUF and HTTP embedding backends are documented in the [retrieval workflow guide](docs/guides/retrieval-workflow.md).
 
 ```bash
 codegraph embed                # Build embeddings (default: nomic-v1.5)
@@ -405,8 +405,11 @@ codegraph search "parse config" --min-score 0.4 -n 10
 codegraph search "parseConfig" --mode keyword   # BM25 keyword-only (exact names)
 codegraph search "auth flow" --mode semantic    # Embedding-only (conceptual)
 codegraph search "auth flow" --mode hybrid      # BM25 + semantic RRF fusion (default)
+codegraph search "auth flow" --expand --explain # Expansion + source metadata
 codegraph models               # List available models
 ```
+
+For model roles/presets, re-embedding after model changes, stale-vector recovery, offline/cache policy, local GGUF setup, HTTP backends, expansion/rerank controls, structured query modes, and GNO attribution, see [Retrieval Workflow Guide](docs/guides/retrieval-workflow.md).
 
 #### Multi-query search
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,4 +1,10 @@
-# Token Savings Benchmark
+# Benchmarks
+
+## Retrieval Model Benchmark
+
+See [RETRIEVAL.md](./RETRIEVAL.md) for the reproducible, local-only benchmark comparing Codegraph's current embedding path, existing alternatives, and the GNO/Qwen-style preset path on code-focused retrieval fixtures.
+
+## Token Savings Benchmark
 
 Quantifies how much codegraph reduces token usage when AI agents navigate large codebases, compared to raw file exploration (Glob/Grep/Read/Bash).
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -2,7 +2,7 @@
 
 ## Retrieval Model Benchmark
 
-See [RETRIEVAL.md](./RETRIEVAL.md) for the reproducible, local-only benchmark comparing Codegraph's current embedding path, existing alternatives, and the GNO/Qwen-style preset path on code-focused retrieval fixtures.
+See [RETRIEVAL.md](./RETRIEVAL.md) for the reproducible, local-only benchmark comparing Codegraph's current embedding path, existing alternatives, and the GNO/Qwen-style preset path on code-focused retrieval fixtures. For operational setup and migration guidance, see the [retrieval workflow guide](../guides/retrieval-workflow.md).
 
 ## Token Savings Benchmark
 

--- a/docs/benchmarks/RETRIEVAL.md
+++ b/docs/benchmarks/RETRIEVAL.md
@@ -1,0 +1,48 @@
+# Retrieval Model Benchmark
+
+`scripts/retrieval-benchmark.ts` compares Codegraph's current embedding baseline, existing notable alternatives, and the GNO/Qwen-style preset path on bundled code-retrieval fixtures.
+
+## What it measures
+
+Fixtures cover:
+
+- **Code intent search** — natural-language behavior queries.
+- **Identifier search** — exact symbol/constant lookup.
+- **Graph-aware symbol context** — queries that require callers/imports/surrounding context in symbol text.
+- **Ambiguous natural-language queries** — user phrasing that should map to implementation concepts.
+
+Compared model lanes:
+
+- `current-default` (`nomic-v1.5`) — current Codegraph default; this benchmark does not change it.
+- `minilm-baseline` — fast legacy transformer baseline.
+- `jina-code` — existing code-aware transformer alternative.
+- `gno-qwen-compact` — Qwen embedding role from the GNO-inspired compact preset.
+
+Output is JSON with `hitAt1`, `hitAt3`, `hitAt5`, `mrr`, per-query ranks, elapsed embedding/search time, and local embedding-cost counts. Cloud cost is always reported as `0` because the benchmark is designed for local/offline runs.
+
+## CI-safe smoke run (default)
+
+The default mode is deterministic and does not load models, download weights, or call cloud services:
+
+```bash
+node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/retrieval-benchmark.ts --mock --top-k 3 > retrieval-smoke.json
+```
+
+This mode validates fixture coverage, model-lane wiring, metrics, and machine-readable output shape.
+
+## Real local benchmark
+
+Real mode embeds the bundled fixtures with local model runtimes. Build first so the script can import compiled Codegraph modules:
+
+```bash
+npm run build
+CODEGRAPH_NO_AUTO_DOWNLOAD=1 node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/retrieval-benchmark.ts --real > retrieval-real.json
+```
+
+Notes:
+
+- No cloud service or API key is required.
+- Transformer lanes may use the local Hugging Face cache used by `@huggingface/transformers`.
+- The Qwen/GGUF lane requires optional `node-llama-cpp` and a cached GGUF model file for the `hf:` URI, or an explicitly allowed local download.
+- By default, use `CODEGRAPH_NO_AUTO_DOWNLOAD=1` or omit `--allow-downloads` to avoid surprise downloads. To permit local model downloads intentionally, pass `--allow-downloads`.
+- Issue #13 owns any decision to change the default model; benchmark results are evidence only.

--- a/docs/benchmarks/RETRIEVAL.md
+++ b/docs/benchmarks/RETRIEVAL.md
@@ -42,7 +42,8 @@ CODEGRAPH_NO_AUTO_DOWNLOAD=1 node --experimental-strip-types --import ./scripts/
 Notes:
 
 - No cloud service or API key is required.
-- Transformer lanes may use the local Hugging Face cache used by `@huggingface/transformers`.
-- The Qwen/GGUF lane requires optional `node-llama-cpp` and a cached GGUF model file for the `hf:` URI, or an explicitly allowed local download.
-- By default, use `CODEGRAPH_NO_AUTO_DOWNLOAD=1` or omit `--allow-downloads` to avoid surprise downloads. To permit local model downloads intentionally, pass `--allow-downloads`.
+- Transformer lanes use `@huggingface/transformers` and may read the local Hugging Face cache or use network downloads according to that runtime's environment settings (for example `HF_HUB_OFFLINE`). The benchmark's `--allow-downloads` flag does not override transformer-runtime policy.
+- The Qwen/GGUF lane requires optional `node-llama-cpp` and a cached GGUF model file for the `hf:` URI, or an explicitly allowed Codegraph GGUF cache download.
+- By default, use `CODEGRAPH_NO_AUTO_DOWNLOAD=1`, `HF_HUB_OFFLINE=1`, or omit `--allow-downloads` to avoid surprise downloads across lanes. To permit Codegraph GGUF model downloads intentionally, pass `--allow-downloads`.
+- The real benchmark currently creates separate document and query embedding ports for the same model so asymmetric input formatting is measured correctly. On GGUF/Qwen runs this can mean two wrappers for one model; plan memory/VRAM accordingly.
 - Issue #13 owns any decision to change the default model; benchmark results are evidence only.

--- a/docs/benchmarks/RETRIEVAL.md
+++ b/docs/benchmarks/RETRIEVAL.md
@@ -13,10 +13,21 @@ Fixtures cover:
 
 Compared model lanes:
 
-- `current-default` (`nomic-v1.5`) — current Codegraph default; this benchmark does not change it.
+- `current-default` (`nomic-v1.5`) — legacy Codegraph default kept for compatibility comparisons.
 - `minilm-baseline` — fast legacy transformer baseline.
 - `jina-code` — existing code-aware transformer alternative.
 - `gno-qwen-compact` — Qwen embedding role from the GNO-inspired compact preset.
+
+## Issue #13 decision summary
+
+Maintainer decision: switch defaults now to the GNO/Qwen compact path for all retrieval roles. `gno-compact` is the default preset, and the default embedding role is `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf`.
+
+Review summary from the benchmark lane design and migration assessment:
+
+- **Quality:** the GNO/Qwen compact lane is the target higher-quality code retrieval path and is now preferred over the legacy `nomic-v1.5` baseline; the benchmark continues to keep legacy lanes so regressions can be compared.
+- **Speed:** the compact Qwen GGUF role is the smallest GNO lane and avoids making the balanced/quality generation models the default path. Real speed still depends on local `node-llama-cpp` hardware/runtime.
+- **Install size:** default use may require optional `node-llama-cpp` plus the cached Qwen GGUF embedding file. Codegraph still avoids test-time or smoke-benchmark downloads, and explicit legacy transformer aliases remain available for smaller installs.
+- **Migration impact:** existing `.codegraphrc` files with `embeddings.model` such as `nomic-v1.5` continue to override the default embedding role. The `codegraph-default` preset remains available as a legacy compatibility preset.
 
 Output is JSON with `hitAt1`, `hitAt3`, `hitAt5`, `mrr`, per-query ranks, elapsed embedding/search time, and local embedding-cost counts. Cloud cost is always reported as `0` because the benchmark is designed for local/offline runs.
 
@@ -46,4 +57,4 @@ Notes:
 - The Qwen/GGUF lane requires optional `node-llama-cpp` and a cached GGUF model file for the `hf:` URI, or an explicitly allowed Codegraph GGUF cache download.
 - By default, use `CODEGRAPH_NO_AUTO_DOWNLOAD=1`, `HF_HUB_OFFLINE=1`, or omit `--allow-downloads` to avoid surprise downloads across lanes. To permit Codegraph GGUF model downloads intentionally, pass `--allow-downloads`.
 - The real benchmark currently creates separate document and query embedding ports for the same model so asymmetric input formatting is measured correctly. On GGUF/Qwen runs this can mean two wrappers for one model; plan memory/VRAM accordingly.
-- Issue #13 owns any decision to change the default model; benchmark results are evidence only.
+- Issue #13 resolved the default decision in favor of GNO/Qwen compact defaults. Keep this benchmark as regression evidence and run with explicit download/cache policy.

--- a/docs/examples/CLI.md
+++ b/docs/examples/CLI.md
@@ -705,13 +705,15 @@ codegraph models
 ```
 Available embedding models:
 
-  minilm        384d  256 ctx   Smallest, fastest (~23MB). General text. (default)
+  minilm        384d  256 ctx   Smallest, fastest (~23MB). General text.
   jina-small    512d  8192 ctx  Small, good quality (~33MB). General text.
   jina-base     768d  8192 ctx  Good quality (~137MB). General text, 8192 token context.
   jina-code     768d  8192 ctx  Code-aware (~137MB). Trained on code+text, best for code search.
   nomic         768d  8192 ctx  Good local quality (~137MB). 8192 context.
   nomic-v1.5    768d  8192 ctx  Improved nomic (~137MB). Matryoshka dimensions, 8192 context.
   bge-large    1024d  512 ctx   Best general retrieval (~335MB). Top MTEB scores.
+
+Default embedding role: hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf
 ```
 
 ---

--- a/docs/guides/ai-agent-guide.md
+++ b/docs/guides/ai-agent-guide.md
@@ -556,13 +556,14 @@ Generate embeddings for all symbols. Required before `search` works.
 
 ```bash
 codegraph embed .
-codegraph embed . --model jina-code
+codegraph embed . --model hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf
+codegraph embed . --model nomic-v1.5
 ```
 
 | | |
 |---|---|
 | **MCP tool** | (use via CLI) |
-| **Key flags** | `-m, --model` (minilm, jina-small, jina-base, jina-code, nomic, nomic-v1.5, bge-large) |
+| **Key flags** | `-m, --model <name-or-uri>` (defaults to the GNO/Qwen embedding model; legacy names such as `nomic-v1.5` remain available) |
 | **When to use** | Initial setup, or after adding many new functions |
 
 #### `export` — Export graph

--- a/docs/guides/retrieval-workflow.md
+++ b/docs/guides/retrieval-workflow.md
@@ -2,7 +2,7 @@
 
 This guide covers Codegraph's current retrieval workflow for semantic and hybrid search: model roles, embedding, cache policy, query expansion, reranking, stale-vector recovery, and migration from legacy config.
 
-The default embedding model remains `nomic-v1.5`. Issue #13 owns any future default-model decision.
+Issue #13 decision: Codegraph now uses the GNO/Qwen compact defaults for all retrieval roles. The default preset is `gno-compact`, and the default embedding role is `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf`.
 
 ## Quick workflow
 
@@ -29,8 +29,8 @@ Codegraph resolves retrieval models by role:
 
 Built-in presets are defined in `src/domain/search/models.ts`:
 
-- `codegraph-default` — compatibility preset. It keeps the current Codegraph embedding default (`nomic-v1.5`) and wires GNO-inspired retrieval roles for the optional stages.
-- `gno-compact` — compact local Qwen/GGUF embedding, rerank, expansion, and generation roles.
+- `gno-compact` — default compact local Qwen/GGUF embedding, rerank, expansion, and generation roles.
+- `codegraph-default` — legacy compatibility preset. It keeps the previous Codegraph embedding default (`nomic-v1.5`) and wires GNO-inspired retrieval roles for the optional stages.
 - `gno-balanced` — Qwen embedding/rerank with a larger expansion/generation role.
 - `gno-quality` — Qwen embedding/rerank with the largest built-in expansion/generation role.
 
@@ -62,7 +62,7 @@ Existing single-model config still works:
 }
 ```
 
-When the selected preset is `codegraph-default`, `embeddings.model` is treated as the embedding role unless `models.roles.embed` is set. Non-default presets use their preset embedding role unless explicitly overridden. The `codegraph embed --model <name-or-uri>` flag overrides config for that embedding run. `codegraph search --model <name-or-uri>` can override the query embedding model for a search, but normal use should let search auto-detect the model recorded during `embed`.
+Existing configs keep working after the default switch: an explicit `embeddings.model` value such as `nomic-v1.5` is treated as the embedding role unless `models.roles.embed` is set. Other non-default presets use their preset embedding role unless explicitly overridden. To retain the full previous behavior, set `models.preset` to `codegraph-default` and re-run `codegraph embed`. The `codegraph embed --model <name-or-uri>` flag overrides config for that embedding run. `codegraph search --model <name-or-uri>` can override the query embedding model for a search, but normal use should let search auto-detect the model recorded during `embed`.
 
 ## Embedding and re-embedding
 

--- a/docs/guides/retrieval-workflow.md
+++ b/docs/guides/retrieval-workflow.md
@@ -94,22 +94,35 @@ Re-embed after:
 
 ### Clearing stale vectors
 
-The normal recovery path is to re-run embedding with the desired model and strategy:
+The normal recovery path is to build first, then re-run embedding with the desired model and strategy:
 
 ```bash
+codegraph build
 codegraph embed --model <model-or-uri> --strategy structured
 ```
 
 This refreshes the primary `embeddings`, `embedding_meta`, and FTS rows and replaces vectors for the active model/profile storage key.
 
-If you want to remove all vector generations and rebuild from a clean slate, use a SQLite backup first, then clear the embedding tables:
+For a full clean slate, back up or remove the database and rebuild it:
 
 ```bash
 cp .codegraph/graph.db .codegraph/graph.db.bak
-sqlite3 .codegraph/graph.db \
-  "DELETE FROM embeddings; DELETE FROM embedding_meta; DELETE FROM fts_index; DELETE FROM embedding_vectors; DELETE FROM embedding_vector_index_meta;"
+rm .codegraph/graph.db
+codegraph build
 codegraph embed --model <model-or-uri> --strategy structured
 ```
+
+If you must preserve the graph tables and only clear search/vector state, use `DROP TABLE IF EXISTS` so older databases without newer tables are handled safely:
+
+```sql
+DROP TABLE IF EXISTS embeddings;
+DROP TABLE IF EXISTS embedding_meta;
+DROP TABLE IF EXISTS fts_index;
+DROP TABLE IF EXISTS embedding_vectors;
+DROP TABLE IF EXISTS embedding_vector_index_meta;
+```
+
+When sqlite-vec acceleration has been used, also inspect `sqlite_master` for virtual tables named `vec_embeddings_*` and drop each stale table with `DROP TABLE IF EXISTS` before re-running `codegraph embed`.
 
 If results still appear stale after large graph changes, rebuild the graph and then re-embed:
 
@@ -285,4 +298,4 @@ Codegraph's model-role architecture and retrieval workflow adapt design and code
 
 GNO source reference: https://github.com/gmickel/gno.
 
-GNO is MIT licensed: MIT License, Copyright (c) 2025 Gordon Mickel.
+GNO license: https://github.com/gmickel/gno/blob/main/LICENSE — MIT License, Copyright (c) 2025 Gordon Mickel.

--- a/docs/guides/retrieval-workflow.md
+++ b/docs/guides/retrieval-workflow.md
@@ -11,7 +11,7 @@ codegraph build
 codegraph embed                         # uses config/default embedding model and structured symbol text
 codegraph search "handle auth"          # hybrid BM25 + semantic search
 codegraph search "parseConfig" --mode keyword
-codegraph search "auth flow" --expand --explain
+codegraph search "auth" --query-mode term:auth --query-mode intent:"validate bearer token"
 ```
 
 Re-run `codegraph embed` whenever you change the embedding model, embedding strategy, compatibility profile, or after a full graph rebuild that makes stored embeddings stale.
@@ -183,7 +183,7 @@ Transformer models are loaded through `@huggingface/transformers`; that runtime 
 - `@huggingface/transformers` is optional and lazy-loaded for transformer embeddings. If missing, Codegraph prompts in TTY sessions or attempts non-interactive install; otherwise it tells you to install it.
 - `node-llama-cpp` is optional and only needed for GGUF models.
 - `sqlite-vec` support is optional. When vector acceleration is unavailable, Codegraph stores vectors in SQLite and semantic search falls back to brute-force vector comparison.
-- Reranking is optional. If no supported rerank port is available or reranking fails, hybrid search falls back to fusion-only results.
+- Reranking is optional. Without a supported HTTP rerank endpoint, hybrid search skips reranking. If a configured rerank endpoint fails, hybrid search falls back to fusion-only results.
 
 ## Expansion, structured query modes, fusion, and reranking
 
@@ -214,12 +214,12 @@ CLI controls:
 
 ```bash
 codegraph search "auth flow" --mode hybrid
-codegraph search "auth flow" --expand
+codegraph search "auth flow" --expand   # Allows model expansion only when a provider is wired
 codegraph search "auth flow" --no-expand
 codegraph search "auth flow" --rrf-k 30
 codegraph search "auth flow" --explain --json
 codegraph search "parseConfig" --query-mode term:parseConfig
-codegraph search "auth" --query-mode intent:"validate bearer token" --query-mode hyde:"Middleware validates a bearer token before calling the handler."
+codegraph search "auth" --query-mode term:auth --query-mode intent:"validate bearer token"
 ```
 
 Structured query modes:
@@ -239,8 +239,8 @@ Expansion behavior:
 
 - Expansion is off for CLI hybrid search unless `--expand` is passed or structured query modes are provided.
 - `--query-mode` structured entries work without a model provider because the user/agent supplies the lexical, intent, or HyDE text explicitly.
-- Model-generated expansion requires an expansion provider to be wired by the caller; `--expand`/`expand` controls whether that provider is allowed to add variants.
-- MCP `semantic_search` exposes `expand`, `no_expand`, `query_mode`, `query_modes`, and `explain`; its default hybrid request path allows expansion unless disabled.
+- Model-generated expansion requires an expansion provider to be wired by the caller; current CLI/MCP paths do not create one automatically, so `--expand`/`expand` can be skipped with `no_provider`.
+- MCP `semantic_search` exposes `expand`, `no_expand`, `query_mode`, `query_modes`, and `explain`; structured modes add routed variants without a provider.
 - Expansion guardrails preserve quoted phrases, negations, acronyms, and code-like symbols, and drop variants that drift too far from the original query.
 - Strong exact BM25 signals can skip model expansion so precise identifier searches stay fast.
 
@@ -251,9 +251,10 @@ Reranking behavior:
 - Reranking only applies to the top fused candidates (`maxCandidates`/`rerank_candidates`).
 - Scores are blended with fusion according to `fusionWeight` and `rerankWeight`.
 - The top exact lexical hit is protected from rerank-only demotion.
-- If the reranker is missing or errors, search returns fusion-only results with fallback metadata when `--explain`/`explain` is enabled.
+- If no HTTP rerank endpoint is configured, reranking is skipped and no rerank metadata is attached.
+- If a configured rerank endpoint errors, search returns fusion-only ordering and JSON results include rerank fallback metadata.
 
-Use `--explain --json` to inspect source contributions (`bm25`, `bm25_variant`, `vector`, `vector_variant`, `hyde`) and rerank metadata when available.
+Use `--explain --json` to inspect source contributions (`bm25`, `bm25_variant`, `vector`, `vector_variant`, `hyde`). JSON output includes rerank metadata when reranking runs or a configured reranker errors.
 
 ## Speed vs. quality guidance
 
@@ -282,6 +283,6 @@ Use `--explain --json` to inspect source contributions (`bm25`, `bm25_variant`, 
 
 Codegraph's model-role architecture and retrieval workflow adapt design and code ideas from the GNO retrieval modules where applicable, including role-separated retrieval models, GGUF/cache policy concepts, query expansion, weighted fusion, reranking guardrails, and resilient embedding behavior.
 
-GNO source reference: `/tmp/pi-github-repos/gmickel/gno`.
+GNO source reference: https://github.com/gmickel/gno.
 
-GNO is MIT licensed: Copyright (c) 2025 Gordon Mickel.
+GNO is MIT licensed: MIT License, Copyright (c) 2025 Gordon Mickel.

--- a/docs/guides/retrieval-workflow.md
+++ b/docs/guides/retrieval-workflow.md
@@ -1,0 +1,287 @@
+# Retrieval Workflow Guide
+
+This guide covers Codegraph's current retrieval workflow for semantic and hybrid search: model roles, embedding, cache policy, query expansion, reranking, stale-vector recovery, and migration from legacy config.
+
+The default embedding model remains `nomic-v1.5`. Issue #13 owns any future default-model decision.
+
+## Quick workflow
+
+```bash
+codegraph build
+codegraph embed                         # uses config/default embedding model and structured symbol text
+codegraph search "handle auth"          # hybrid BM25 + semantic search
+codegraph search "parseConfig" --mode keyword
+codegraph search "auth flow" --expand --explain
+```
+
+Re-run `codegraph embed` whenever you change the embedding model, embedding strategy, compatibility profile, or after a full graph rebuild that makes stored embeddings stale.
+
+## Model roles, presets, and overrides
+
+Codegraph resolves retrieval models by role:
+
+| Role | Purpose | Used by |
+| --- | --- | --- |
+| `embed` | Creates vectors for indexed symbols and search queries. | `codegraph embed`, semantic/hybrid search |
+| `rerank` | Optional cross-encoder-style final ranking of fused candidates. | Hybrid search when reranking is enabled |
+| `expand` | Optional query expansion model for lexical/vector variants and HyDE text. | Expansion-capable callers/providers |
+| `gen` | Reserved generation role for workflows that need text generation. | Shared model-role config |
+
+Built-in presets are defined in `src/domain/search/models.ts`:
+
+- `codegraph-default` — compatibility preset. It keeps the current Codegraph embedding default (`nomic-v1.5`) and wires GNO-inspired retrieval roles for the optional stages.
+- `gno-compact` — compact local Qwen/GGUF embedding, rerank, expansion, and generation roles.
+- `gno-balanced` — Qwen embedding/rerank with a larger expansion/generation role.
+- `gno-quality` — Qwen embedding/rerank with the largest built-in expansion/generation role.
+
+Configure a preset and role overrides in `.codegraphrc.json`:
+
+```json
+{
+  "models": {
+    "preset": "gno-compact",
+    "roles": {
+      "embed": "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf",
+      "rerank": "https://reranker.example/v1/rerank"
+    }
+  }
+}
+```
+
+Role overrides can be transformer model names, full transformer model IDs, `hf:` GGUF URIs, `file:`/absolute GGUF paths, or HTTP(S) endpoints where supported by the role. Embedding also accepts legacy Codegraph model aliases such as `minilm`, `jina-code`, and `nomic-v1.5`.
+
+### Legacy config compatibility
+
+Existing single-model config still works:
+
+```json
+{
+  "embeddings": {
+    "model": "nomic-v1.5"
+  }
+}
+```
+
+When the selected preset is `codegraph-default`, `embeddings.model` is treated as the embedding role unless `models.roles.embed` is set. Non-default presets use their preset embedding role unless explicitly overridden. The `codegraph embed --model <name-or-uri>` flag overrides config for that embedding run. `codegraph search --model <name-or-uri>` can override the query embedding model for a search, but normal use should let search auto-detect the model recorded during `embed`.
+
+## Embedding and re-embedding
+
+Build the graph first, then embed symbols:
+
+```bash
+codegraph build
+codegraph embed
+codegraph embed --strategy structured
+codegraph embed --strategy source
+codegraph embed --model jina-code
+codegraph embed --model hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf
+```
+
+Strategies:
+
+- `structured` (default) embeds graph-aware symbol text with context such as callers/callees where available.
+- `source` embeds raw source for the symbol range.
+
+`codegraph embed` stores model metadata in the database: model URI, dimension, strategy, compatibility profile, formatter version, and build timestamp. Search compares stored metadata with the active model/profile and warns if vectors may be stale or incompatible.
+
+Re-embed after:
+
+- Changing `embeddings.model`, `models.preset`, or `models.roles.embed`.
+- Passing a different `codegraph embed --model` value.
+- Changing `--strategy` between `structured` and `source`.
+- Updating Codegraph in a way that changes the embedding formatter/profile.
+- Rebuilding the graph after broad file moves or large refactors.
+
+### Clearing stale vectors
+
+The normal recovery path is to re-run embedding with the desired model and strategy:
+
+```bash
+codegraph embed --model <model-or-uri> --strategy structured
+```
+
+This refreshes the primary `embeddings`, `embedding_meta`, and FTS rows and replaces vectors for the active model/profile storage key.
+
+If you want to remove all vector generations and rebuild from a clean slate, use a SQLite backup first, then clear the embedding tables:
+
+```bash
+cp .codegraph/graph.db .codegraph/graph.db.bak
+sqlite3 .codegraph/graph.db \
+  "DELETE FROM embeddings; DELETE FROM embedding_meta; DELETE FROM fts_index; DELETE FROM embedding_vectors; DELETE FROM embedding_vector_index_meta;"
+codegraph embed --model <model-or-uri> --strategy structured
+```
+
+If results still appear stale after large graph changes, rebuild the graph and then re-embed:
+
+```bash
+codegraph build --no-incremental
+codegraph embed --model <model-or-uri> --strategy structured
+```
+
+## Local GGUF setup
+
+GGUF model URIs are handled by the model cache in `~/.codegraph/models` by default.
+
+Supported URI forms:
+
+```text
+hf:org/repo/model.gguf
+hf:org/repo:QUANT
+file:/absolute/path/model.gguf
+file:///absolute/path/model.gguf
+/absolute/path/model.gguf
+```
+
+Local GGUF embedding requires the optional runtime:
+
+```bash
+npm install node-llama-cpp
+```
+
+If the runtime is not installed and a GGUF model is selected, Codegraph reports that `node-llama-cpp` is required. Users who only build graphs, run keyword search, or use transformer embeddings do not need this dependency.
+
+Codegraph validates cached GGUF files before use. If a file is missing the `GGUF` magic header, or appears to be HTML from a proxy/login page, remove the bad file and download/cache it again.
+
+## HTTP embedding backend setup
+
+Embedding roles can point at an HTTP(S) endpoint that behaves like an OpenAI-compatible embeddings API:
+
+```json
+{
+  "models": {
+    "roles": {
+      "embed": "https://models.example/v1/embeddings#text-embedding-model"
+    }
+  }
+}
+```
+
+The part before `#` is the API URL. The part after `#` is sent as the `model` field. Without `#`, Codegraph derives a model name from the last URL path segment. Requests use:
+
+```json
+{ "input": ["text one", "text two"], "model": "text-embedding-model" }
+```
+
+Responses must include a `data` array with one embedding per input. `index` values are honored when present.
+
+## Offline and download policy
+
+GGUF cache/download policy is explicit:
+
+| Control | Effect |
+| --- | --- |
+| `CODEGRAPH_OFFLINE=1` or `HF_HUB_OFFLINE=1` | Offline mode. Codegraph will not download and errors if the model is not cached. |
+| `CODEGRAPH_NO_AUTO_DOWNLOAD=1` | Network is allowed generally, but Codegraph will not auto-download GGUF models. |
+| Default | Codegraph may ask `node-llama-cpp` to resolve/download uncached GGUF models. |
+
+For deterministic local runs, pre-cache model files under `~/.codegraph/models` or use `file:`/absolute paths, then set offline/no-download controls.
+
+Transformer models are loaded through `@huggingface/transformers`; that runtime has its own cache and environment policy. The retrieval benchmark guide recommends `CODEGRAPH_NO_AUTO_DOWNLOAD=1` and/or `HF_HUB_OFFLINE=1` for no-surprise benchmark runs. See [`docs/benchmarks/RETRIEVAL.md`](../benchmarks/RETRIEVAL.md).
+
+## Optional dependencies and fallback behavior
+
+- `@huggingface/transformers` is optional and lazy-loaded for transformer embeddings. If missing, Codegraph prompts in TTY sessions or attempts non-interactive install; otherwise it tells you to install it.
+- `node-llama-cpp` is optional and only needed for GGUF models.
+- `sqlite-vec` support is optional. When vector acceleration is unavailable, Codegraph stores vectors in SQLite and semantic search falls back to brute-force vector comparison.
+- Reranking is optional. If no supported rerank port is available or reranking fails, hybrid search falls back to fusion-only results.
+
+## Expansion, structured query modes, fusion, and reranking
+
+Hybrid search combines BM25 keyword hits and semantic vector hits with weighted Reciprocal Rank Fusion (RRF). Relevant config defaults live under `search` in `.codegraphrc.json`:
+
+```json
+{
+  "search": {
+    "rrfK": 60,
+    "rrfWeights": {
+      "bm25": 2,
+      "bm25Variant": 0.5,
+      "vector": 2,
+      "vectorVariant": 0.5,
+      "hyde": 0.7
+    },
+    "rerank": {
+      "enabled": false,
+      "maxCandidates": 20,
+      "fusionWeight": 0.4,
+      "rerankWeight": 0.6
+    }
+  }
+}
+```
+
+CLI controls:
+
+```bash
+codegraph search "auth flow" --mode hybrid
+codegraph search "auth flow" --expand
+codegraph search "auth flow" --no-expand
+codegraph search "auth flow" --rrf-k 30
+codegraph search "auth flow" --explain --json
+codegraph search "parseConfig" --query-mode term:parseConfig
+codegraph search "auth" --query-mode intent:"validate bearer token" --query-mode hyde:"Middleware validates a bearer token before calling the handler."
+```
+
+Structured query modes:
+
+- `term:<text>` adds exact/lexical BM25-oriented terms.
+- `intent:<text>` adds semantic intent text for vector retrieval and rerank intent.
+- `hyde:<text>` supplies one hypothetical answer/document passage for vector retrieval.
+
+Rules enforced by the parser:
+
+- `--query-mode` is repeatable.
+- Only one HyDE entry is allowed.
+- HyDE-only input is rejected; include a plain query, `term`, or `intent` entry.
+- Structured query documents can also use `term:`, `intent:`, and `hyde:` line prefixes.
+
+Expansion behavior:
+
+- Expansion is off for CLI hybrid search unless `--expand` is passed or structured query modes are provided.
+- `--query-mode` structured entries work without a model provider because the user/agent supplies the lexical, intent, or HyDE text explicitly.
+- Model-generated expansion requires an expansion provider to be wired by the caller; `--expand`/`expand` controls whether that provider is allowed to add variants.
+- MCP `semantic_search` exposes `expand`, `no_expand`, `query_mode`, `query_modes`, and `explain`; its default hybrid request path allows expansion unless disabled.
+- Expansion guardrails preserve quoted phrases, negations, acronyms, and code-like symbols, and drop variants that drift too far from the original query.
+- Strong exact BM25 signals can skip model expansion so precise identifier searches stay fast.
+
+Reranking behavior:
+
+- Config `search.rerank.enabled` or request-level MCP `rerank` enables reranking; `no_rerank` disables it for that request.
+- CLI search currently exposes expansion and explain controls; MCP also exposes `rerank`, `no_rerank`, and `rerank_candidates`.
+- Reranking only applies to the top fused candidates (`maxCandidates`/`rerank_candidates`).
+- Scores are blended with fusion according to `fusionWeight` and `rerankWeight`.
+- The top exact lexical hit is protected from rerank-only demotion.
+- If the reranker is missing or errors, search returns fusion-only results with fallback metadata when `--explain`/`explain` is enabled.
+
+Use `--explain --json` to inspect source contributions (`bm25`, `bm25_variant`, `vector`, `vector_variant`, `hyde`) and rerank metadata when available.
+
+## Speed vs. quality guidance
+
+- Fast exact lookup: `codegraph search "parseConfig" --mode keyword`.
+- Fast semantic search without expansion: `codegraph search "auth flow" --mode semantic` or hybrid with `--no-expand`.
+- Better recall: hybrid search with explicit `term`/`intent`/`hyde` structured modes, or `--expand` when an expansion provider is wired.
+- More stable final ordering: enable reranking where a supported rerank backend is configured, accepting extra latency over the top candidate set.
+- Larger GGUF expansion/generation roles can improve query expansion quality but need more disk, RAM/VRAM, and startup time.
+- Lower `--rrf-k` values emphasize top-ranked source hits more strongly; higher values smooth rankings across sources.
+
+## Troubleshooting
+
+| Symptom | Action |
+| --- | --- |
+| `No codegraph database found` | Run `codegraph build` first or pass `--db`. |
+| Search warns that stored embeddings may be stale/incompatible | Re-run `codegraph embed --model <active-model> --strategy <strategy>`. |
+| Search results do not reflect moved/deleted files | Run `codegraph build --no-incremental`, then re-embed. |
+| GGUF model is not cached in offline mode | Add it to `~/.codegraph/models`, add a manifest entry, use `file:`, or disable offline mode intentionally. |
+| GGUF file looks like HTML or is missing the GGUF header | Delete the bad file and re-download through an authenticated/unblocked network path. |
+| `node-llama-cpp` missing | Install it only if using GGUF models: `npm install node-llama-cpp`. |
+| Transformer runtime missing | Install `@huggingface/transformers` if using transformer embeddings. |
+| HTTP embedding returns the wrong number of vectors | Fix the backend to return one `data[*].embedding` per input, with correct `index` values if reordering. |
+| Reranker unavailable | Disable reranking or configure a supported HTTP rerank endpoint; fusion-only search still works. |
+
+## Attribution
+
+Codegraph's model-role architecture and retrieval workflow adapt design and code ideas from the GNO retrieval modules where applicable, including role-separated retrieval models, GGUF/cache policy concepts, query expansion, weighted fusion, reranking guardrails, and resilient embedding behavior.
+
+GNO source reference: `/tmp/pi-github-repos/gmickel/gno`.
+
+GNO is MIT licensed: Copyright (c) 2025 Gordon Mickel.

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,10 +75,14 @@
         "@optave/codegraph-win32-x64-msvc": "3.9.5"
       },
       "peerDependencies": {
-        "@huggingface/transformers": "^4.0.1"
+        "@huggingface/transformers": "^4.0.1",
+        "node-llama-cpp": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "@huggingface/transformers": {
+          "optional": true
+        },
+        "node-llama-cpp": {
           "optional": true
         }
       }
@@ -7367,6 +7371,7 @@
       "resolved": "git+ssh://git@github.com/gleam-lang/tree-sitter-gleam.git#1627dc5101e63bf19717c540a56df5ef20b1fc7a",
       "integrity": "sha512-ysgcjQzunTVX0hBoUXWRU7YCrzOVSJlT3bHzrq78E3eE1iu1RQ3+RrwKjXEPVPInOmunuS+gHf6LWd8MyXZ4UQ==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "nan": "^2.18.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,13 +76,17 @@
       },
       "peerDependencies": {
         "@huggingface/transformers": "^4.0.1",
-        "node-llama-cpp": "^3.0.0"
+        "node-llama-cpp": "^3.0.0",
+        "sqlite-vec": "^0.1.9"
       },
       "peerDependenciesMeta": {
         "@huggingface/transformers": {
           "optional": true
         },
         "node-llama-cpp": {
+          "optional": true
+        },
+        "sqlite-vec": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "tsc && node -e \"require('fs').writeFileSync('dist/index.cjs',require('fs').readFileSync('src/index.cjs','utf8').replaceAll('./index.ts','./index.js'))\"",
+    "build": "tsc --build --force && node -e \"require('fs').mkdirSync('dist',{recursive:true});require('fs').writeFileSync('dist/index.cjs',require('fs').readFileSync('src/index.cjs','utf8').replaceAll('./index.ts','./index.js'))\"",
     "build:wasm": "node scripts/node-ts.js scripts/build-wasm.ts",
     "typecheck": "tsc --noEmit",
     "verify-imports": "node scripts/node-ts.js scripts/verify-imports.ts",

--- a/package.json
+++ b/package.json
@@ -122,10 +122,14 @@
     "web-tree-sitter": "^0.26.5"
   },
   "peerDependencies": {
-    "@huggingface/transformers": "^4.0.1"
+    "@huggingface/transformers": "^4.0.1",
+    "node-llama-cpp": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "@huggingface/transformers": {
+      "optional": true
+    },
+    "node-llama-cpp": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -123,13 +123,17 @@
   },
   "peerDependencies": {
     "@huggingface/transformers": "^4.0.1",
-    "node-llama-cpp": "^3.0.0"
+    "node-llama-cpp": "^3.0.0",
+    "sqlite-vec": "^0.1.9"
   },
   "peerDependenciesMeta": {
     "@huggingface/transformers": {
       "optional": true
     },
     "node-llama-cpp": {
+      "optional": true
+    },
+    "sqlite-vec": {
       "optional": true
     }
   },

--- a/scripts/retrieval-benchmark.ts
+++ b/scripts/retrieval-benchmark.ts
@@ -1,0 +1,521 @@
+#!/usr/bin/env node
+
+/**
+ * Code retrieval benchmark harness for comparing legacy transformer models with
+ * the GNO/Qwen-style embedding preset path.
+ *
+ * Default mode is a deterministic mock smoke run: it does not import model
+ * runtimes, download weights, or require cloud services. Pass --mode real to
+ * embed the bundled fixtures with local models you have installed/cached.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export type RetrievalFixtureCategory =
+  | 'code-intent'
+  | 'identifier'
+  | 'graph-aware-symbol-context'
+  | 'ambiguous-natural-language';
+
+export interface RetrievalDocument {
+  id: string;
+  symbol: string;
+  file: string;
+  kind: string;
+  text: string;
+}
+
+export interface RetrievalFixture {
+  id: string;
+  category: RetrievalFixtureCategory;
+  query: string;
+  description: string;
+  relevantSymbolIds: string[];
+  documents: RetrievalDocument[];
+}
+
+export interface BenchmarkModelPreset {
+  id: string;
+  label: string;
+  modelUri: string;
+  rolePreset?: string;
+  notes: string;
+}
+
+export interface QueryResult {
+  fixtureId: string;
+  category: RetrievalFixtureCategory;
+  query: string;
+  expected: string[];
+  retrieved: string[];
+  rank: number | null;
+  reciprocalRank: number;
+  searchMs: number;
+}
+
+export interface ModelBenchmarkResult {
+  label: string;
+  modelUri: string;
+  rolePreset?: string;
+  quality: {
+    hitAt1: number;
+    hitAt3: number;
+    hitAt5: number;
+    mrr: number;
+    queries: number;
+  };
+  runtime: {
+    embedMs: number;
+    searchMs: number;
+    totalMs: number;
+  };
+  embeddingCost: {
+    provider: 'local';
+    documents: number;
+    queries: number;
+    cloudCostUsd: 0;
+  };
+  perQuery: QueryResult[];
+}
+
+export interface RetrievalBenchmarkOutput {
+  benchmark: 'code-retrieval-model-comparison';
+  date: string;
+  mode: 'mock' | 'real';
+  topK: number;
+  fixtures: string[];
+  queries: Array<Pick<RetrievalFixture, 'id' | 'category' | 'query' | 'relevantSymbolIds'>>;
+  models: Record<string, ModelBenchmarkResult>;
+  reproducibility: {
+    noCloudServicesRequired: true;
+    downloadsDefault: 'disabled-in-mock-mode';
+    realModeNote: string;
+  };
+}
+
+export interface RunRetrievalBenchmarkOptions {
+  mode?: 'mock' | 'real';
+  topK?: number;
+  models?: string[];
+  allowDownloads?: boolean;
+}
+
+const DEFAULT_MODEL = 'nomic-v1.5';
+const CURRENT_DEFAULT_MODEL_URI = 'nomic-ai/nomic-embed-text-v1.5';
+const MINILM_MODEL_URI = 'Xenova/all-MiniLM-L6-v2';
+const JINA_CODE_MODEL_URI = 'Xenova/jina-embeddings-v2-base-code';
+const GNO_COMPACT_PRESET = 'gno-compact';
+const GNO_QWEN_EMBED_URI = 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf';
+
+export const BENCHMARK_MODEL_PRESETS: BenchmarkModelPreset[] = [
+  {
+    id: 'current-default',
+    label: `Current default (${DEFAULT_MODEL})`,
+    modelUri: CURRENT_DEFAULT_MODEL_URI,
+    notes: 'Compatibility baseline used by Codegraph today; issue #13 decides whether this changes.',
+  },
+  {
+    id: 'minilm-baseline',
+    label: 'Fast legacy baseline (minilm)',
+    modelUri: MINILM_MODEL_URI,
+    notes: 'Small notable alternative that is cheap to run locally.',
+  },
+  {
+    id: 'jina-code',
+    label: 'Code-aware legacy alternative (jina-code)',
+    modelUri: JINA_CODE_MODEL_URI,
+    notes: 'Existing code-focused transformer option.',
+  },
+  {
+    id: 'gno-qwen-compact',
+    label: 'GNO/Qwen compact preset embed role',
+    modelUri: GNO_QWEN_EMBED_URI,
+    rolePreset: GNO_COMPACT_PRESET,
+    notes: 'Qwen GGUF embedding path from the GNO-inspired preset registry.',
+  },
+];
+
+export const CODE_RETRIEVAL_FIXTURES: RetrievalFixture[] = [
+  {
+    id: 'intent-resilient-batch',
+    category: 'code-intent',
+    query: 'recover embedding batches by retrying smaller chunks after one item fails',
+    description: 'Natural-language intent search for resilient embedding behavior.',
+    relevantSymbolIds: ['embedWithRecovery'],
+    documents: [
+      {
+        id: 'embedWithRecovery',
+        symbol: 'embedWithRecovery',
+        file: 'src/domain/search/ports.ts',
+        kind: 'function',
+        text: 'function embedWithRecovery retries a failed embedding batch by splitting it into smaller chunks, falling back to single-item recovery, and preserving successful vectors.',
+      },
+      {
+        id: 'buildExpansionPrompt',
+        symbol: 'buildExpansionPrompt',
+        file: 'src/domain/search/search/expansion.ts',
+        kind: 'function',
+        text: 'function buildExpansionPrompt asks a local model for lexical variants, semantic intent variants, and one HyDE passage for search expansion.',
+      },
+      {
+        id: 'vectorStorageKey',
+        symbol: 'vectorStorageKey',
+        file: 'src/domain/search/vector-index.ts',
+        kind: 'function',
+        text: 'function vectorStorageKey creates a model-isolated key for vector tables so embeddings from different models do not collide.',
+      },
+    ],
+  },
+  {
+    id: 'identifier-default-model',
+    category: 'identifier',
+    query: 'DEFAULT_RETRIEVAL_PRESET',
+    description: 'Exact identifier lookup should reward lexical/symbol matches.',
+    relevantSymbolIds: ['DEFAULT_RETRIEVAL_PRESET'],
+    documents: [
+      {
+        id: 'DEFAULT_RETRIEVAL_PRESET',
+        symbol: 'DEFAULT_RETRIEVAL_PRESET',
+        file: 'src/domain/search/models.ts',
+        kind: 'constant',
+        text: 'export const DEFAULT_RETRIEVAL_PRESET names the compatibility default retrieval model preset and keeps the current embedding model until benchmark evidence supports a change.',
+      },
+      {
+        id: 'DEFAULT_MODEL',
+        symbol: 'DEFAULT_MODEL',
+        file: 'src/domain/search/models.ts',
+        kind: 'constant',
+        text: 'export const DEFAULT_MODEL is the legacy default embedding model key used by Codegraph semantic search.',
+      },
+      {
+        id: 'resolveRetrievalModels',
+        symbol: 'resolveRetrievalModels',
+        file: 'src/domain/search/models.ts',
+        kind: 'function',
+        text: 'function resolveRetrievalModels combines preset roles, role overrides, and legacy embedding model compatibility.',
+      },
+    ],
+  },
+  {
+    id: 'graph-aware-symbol-context',
+    category: 'graph-aware-symbol-context',
+    query: 'find symbol text that keeps callers imports and surrounding class context for embeddings',
+    description: 'Retrieval should benefit from graph-aware symbol context instead of raw names only.',
+    relevantSymbolIds: ['generateStructuredText'],
+    documents: [
+      {
+        id: 'generateStructuredText',
+        symbol: 'generateStructuredText',
+        file: 'src/domain/search/generator.ts',
+        kind: 'function',
+        text: 'function generateStructuredText builds graph-aware symbol text with file path, kind, signature, imports, callers, callees, and class or module context before embedding.',
+      },
+      {
+        id: 'formatEmbeddingQuery',
+        symbol: 'formatEmbeddingQuery',
+        file: 'src/domain/search/compatibility.ts',
+        kind: 'function',
+        text: 'function formatEmbeddingQuery applies compatibility-specific query instructions for asymmetric embedding models such as Qwen.',
+      },
+      {
+        id: 'hybridSearchData',
+        symbol: 'hybridSearchData',
+        file: 'src/domain/search/search/hybrid.ts',
+        kind: 'function',
+        text: 'function hybridSearchData fuses BM25 lexical results, vector retrieval results, optional expansion variants, and optional reranking metadata.',
+      },
+    ],
+  },
+  {
+    id: 'ambiguous-cache-policy',
+    category: 'ambiguous-natural-language',
+    query: 'do not surprise me by fetching things when I search offline',
+    description: 'Ambiguous user wording should find offline/download policy controls rather than generic search code.',
+    relevantSymbolIds: ['resolveDownloadPolicy'],
+    documents: [
+      {
+        id: 'resolveDownloadPolicy',
+        symbol: 'resolveDownloadPolicy',
+        file: 'src/domain/search/model-cache.ts',
+        kind: 'function',
+        text: 'function resolveDownloadPolicy turns CODEGRAPH_OFFLINE HF_HUB_OFFLINE CODEGRAPH_NO_AUTO_DOWNLOAD and explicit flags into offline and allowDownload controls for local model cache resolution.',
+      },
+      {
+        id: 'searchData',
+        symbol: 'searchData',
+        file: 'src/domain/search/search/semantic.ts',
+        kind: 'function',
+        text: 'function searchData searches an existing vector table and returns semantic search results for a query.',
+      },
+      {
+        id: 'promptInstall',
+        symbol: 'promptInstall',
+        file: 'src/domain/search/models.ts',
+        kind: 'function',
+        text: 'function promptInstall asks an interactive user whether to install an optional semantic search dependency.',
+      },
+    ],
+  },
+];
+
+function tokenize(text: string): string[] {
+  return text
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/)
+    .filter((token) => token.length > 1);
+}
+
+function keywordScore(query: string, doc: RetrievalDocument, preset: BenchmarkModelPreset): number {
+  const queryTokens = tokenize(query);
+  const textTokens = new Set(tokenize(`${doc.symbol} ${doc.file} ${doc.kind} ${doc.text}`));
+  const symbolTokens = new Set(tokenize(doc.symbol));
+  let score = 0;
+  for (const token of queryTokens) {
+    if (textTokens.has(token)) score += 1;
+    if (symbolTokens.has(token)) score += 1.5;
+  }
+  if (doc.symbol.toLowerCase() === query.toLowerCase()) score += 10;
+  if (preset.id === 'jina-code' && /code|symbol|function|identifier|embedding/.test(query)) score += 0.2;
+  if (preset.id === 'gno-qwen-compact' && /intent|context|offline|surprise|recover|smaller/.test(query)) {
+    score += doc.text.includes('function') ? 0.5 : 0;
+  }
+  if (preset.id === 'minilm-baseline') score *= 0.95;
+  return score;
+}
+
+function cosine(left: Float32Array, right: Float32Array): number {
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let i = 0; i < Math.min(left.length, right.length); i++) {
+    const l = left[i] ?? 0;
+    const r = right[i] ?? 0;
+    dot += l * r;
+    leftNorm += l * l;
+    rightNorm += r * r;
+  }
+  return leftNorm && rightNorm ? dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm)) : 0;
+}
+
+function rankFromScored(scored: Array<{ id: string; score: number }>, expected: string[]): number | null {
+  const ordered = scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+  const index = ordered.findIndex((item) => expected.includes(item.id));
+  return index === -1 ? null : index + 1;
+}
+
+async function runMockModel(
+  preset: BenchmarkModelPreset,
+  topK: number,
+): Promise<ModelBenchmarkResult> {
+  const start = performance.now();
+  const perQuery: QueryResult[] = [];
+  let searchMs = 0;
+
+  for (const fixture of CODE_RETRIEVAL_FIXTURES) {
+    const queryStart = performance.now();
+    const scored = fixture.documents.map((doc) => ({
+      id: doc.id,
+      score: keywordScore(fixture.query, doc, preset),
+    }));
+    const ordered = scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+    const elapsed = performance.now() - queryStart;
+    searchMs += elapsed;
+    const rank = rankFromScored([...ordered], fixture.relevantSymbolIds);
+    perQuery.push({
+      fixtureId: fixture.id,
+      category: fixture.category,
+      query: fixture.query,
+      expected: fixture.relevantSymbolIds,
+      retrieved: ordered.slice(0, topK).map((item) => item.id),
+      rank,
+      reciprocalRank: rank ? 1 / rank : 0,
+      searchMs: Math.round(elapsed * 100) / 100,
+    });
+  }
+
+  return summarizeModelResult(preset, perQuery, 0, searchMs, performance.now() - start);
+}
+
+async function loadBuiltSearchModule(): Promise<{
+  createEmbeddingPort: (modelUri: string, options: Record<string, unknown>) => Promise<{
+    embedBatch(texts: string[]): Promise<Float32Array[]>;
+    reset?: () => Promise<void> | void;
+  }>;
+}> {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const builtSearch = path.join(root, 'dist', 'domain', 'search', 'index.js');
+  if (!fs.existsSync(builtSearch)) {
+    throw new Error(
+      'Real retrieval benchmarks require compiled sources. Run `npm run build` first, or use the default --mock smoke mode.',
+    );
+  }
+  return import(pathToFileURL(builtSearch).href) as Promise<{
+    createEmbeddingPort: (modelUri: string, options: Record<string, unknown>) => Promise<{
+      embedBatch(texts: string[]): Promise<Float32Array[]>;
+      reset?: () => Promise<void> | void;
+    }>;
+  }>;
+}
+
+async function runRealModel(
+  preset: BenchmarkModelPreset,
+  topK: number,
+  allowDownloads: boolean,
+): Promise<ModelBenchmarkResult> {
+  const totalStart = performance.now();
+  const { createEmbeddingPort } = await loadBuiltSearchModule();
+  const documentPort = await createEmbeddingPort(preset.modelUri, {
+    inputType: 'document',
+    policy: { offline: !allowDownloads, allowDownload: allowDownloads },
+  });
+  const queryPort = await createEmbeddingPort(preset.modelUri, {
+    inputType: 'query',
+    policy: { offline: !allowDownloads, allowDownload: allowDownloads },
+  });
+
+  const perQuery: QueryResult[] = [];
+  let embedMs = 0;
+  let searchMs = 0;
+
+  for (const fixture of CODE_RETRIEVAL_FIXTURES) {
+    const embedStart = performance.now();
+    const docVectors = await documentPort.embedBatch(fixture.documents.map((doc) => doc.text));
+    const [queryVector] = await queryPort.embedBatch([fixture.query]);
+    embedMs += performance.now() - embedStart;
+
+    const queryStart = performance.now();
+    const scored = fixture.documents.map((doc, index) => ({
+      id: doc.id,
+      score: queryVector ? cosine(queryVector, docVectors[index] ?? new Float32Array()) : 0,
+    }));
+    const ordered = scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+    const elapsed = performance.now() - queryStart;
+    searchMs += elapsed;
+    const rank = rankFromScored([...ordered], fixture.relevantSymbolIds);
+    perQuery.push({
+      fixtureId: fixture.id,
+      category: fixture.category,
+      query: fixture.query,
+      expected: fixture.relevantSymbolIds,
+      retrieved: ordered.slice(0, topK).map((item) => item.id),
+      rank,
+      reciprocalRank: rank ? 1 / rank : 0,
+      searchMs: Math.round(elapsed * 100) / 100,
+    });
+  }
+
+  await documentPort.reset?.();
+  await queryPort.reset?.();
+  return summarizeModelResult(preset, perQuery, embedMs, searchMs, performance.now() - totalStart);
+}
+
+function summarizeModelResult(
+  preset: BenchmarkModelPreset,
+  perQuery: QueryResult[],
+  embedMs: number,
+  searchMs: number,
+  totalMs: number,
+): ModelBenchmarkResult {
+  const queries = perQuery.length;
+  return {
+    label: preset.label,
+    modelUri: preset.modelUri,
+    rolePreset: preset.rolePreset,
+    quality: {
+      hitAt1: perQuery.filter((item) => item.rank === 1).length / queries,
+      hitAt3: perQuery.filter((item) => item.rank != null && item.rank <= 3).length / queries,
+      hitAt5: perQuery.filter((item) => item.rank != null && item.rank <= 5).length / queries,
+      mrr: perQuery.reduce((sum, item) => sum + item.reciprocalRank, 0) / queries,
+      queries,
+    },
+    runtime: {
+      embedMs: Math.round(embedMs),
+      searchMs: Math.round(searchMs),
+      totalMs: Math.round(totalMs),
+    },
+    embeddingCost: {
+      provider: 'local',
+      documents: CODE_RETRIEVAL_FIXTURES.reduce((sum, fixture) => sum + fixture.documents.length, 0),
+      queries,
+      cloudCostUsd: 0,
+    },
+    perQuery,
+  };
+}
+
+export async function runRetrievalBenchmark(
+  options: RunRetrievalBenchmarkOptions = {},
+): Promise<RetrievalBenchmarkOutput> {
+  const mode = options.mode ?? 'mock';
+  const topK = options.topK ?? 5;
+  const selected = options.models?.length
+    ? BENCHMARK_MODEL_PRESETS.filter((preset) => options.models?.includes(preset.id))
+    : BENCHMARK_MODEL_PRESETS;
+  const models: Record<string, ModelBenchmarkResult> = {};
+
+  for (const preset of selected) {
+    models[preset.id] =
+      mode === 'mock'
+        ? await runMockModel(preset, topK)
+        : await runRealModel(preset, topK, options.allowDownloads ?? false);
+  }
+
+  return {
+    benchmark: 'code-retrieval-model-comparison',
+    date: new Date().toISOString().slice(0, 10),
+    mode,
+    topK,
+    fixtures: CODE_RETRIEVAL_FIXTURES.map((fixture) => fixture.id),
+    queries: CODE_RETRIEVAL_FIXTURES.map(({ id, category, query, relevantSymbolIds }) => ({
+      id,
+      category,
+      query,
+      relevantSymbolIds,
+    })),
+    models,
+    reproducibility: {
+      noCloudServicesRequired: true,
+      downloadsDefault: 'disabled-in-mock-mode',
+      realModeNote:
+        'Real mode uses local transformer/GGUF runtimes. Qwen hf: models require node-llama-cpp plus cached GGUF files unless --allow-downloads is passed.',
+    },
+  };
+}
+
+function parseArgs(argv: string[]): RunRetrievalBenchmarkOptions {
+  const options: RunRetrievalBenchmarkOptions = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--mode') options.mode = argv[++i] as 'mock' | 'real';
+    else if (arg === '--real') options.mode = 'real';
+    else if (arg === '--mock') options.mode = 'mock';
+    else if (arg === '--top-k') options.topK = Number(argv[++i]);
+    else if (arg === '--models') options.models = (argv[++i] ?? '').split(',').filter(Boolean);
+    else if (arg === '--allow-downloads') options.allowDownloads = true;
+    else if (arg === '--help' || arg === '-h') {
+      process.stderr.write(
+        'Usage: node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/retrieval-benchmark.ts [--mock|--real] [--top-k N] [--models id,id] [--allow-downloads]\n',
+      );
+      process.exit(0);
+    }
+  }
+  if (options.mode && !['mock', 'real'].includes(options.mode)) {
+    throw new Error(`Invalid --mode ${options.mode}; expected mock or real.`);
+  }
+  return options;
+}
+
+const invokedPath = process.argv[1] ? fileURLToPath(import.meta.url) === process.argv[1] : false;
+if (invokedPath) {
+  try {
+    const output = await runRetrievalBenchmark(parseArgs(process.argv.slice(2)));
+    console.log(JSON.stringify(output, null, 2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/scripts/retrieval-benchmark.ts
+++ b/scripts/retrieval-benchmark.ts
@@ -481,7 +481,7 @@ export async function runRetrievalBenchmark(
       noCloudServicesRequired: true,
       downloadsDefault: 'disabled-in-mock-mode',
       realModeNote:
-        'Real mode uses local transformer/GGUF runtimes. Qwen hf: models require node-llama-cpp plus cached GGUF files unless --allow-downloads is passed.',
+        'Real mode uses local transformer/GGUF runtimes. --allow-downloads only controls Codegraph GGUF hf: cache downloads; transformer lanes may use the Hugging Face cache/network according to @huggingface/transformers environment settings. The Qwen GGUF lane creates separate document/query embedding ports for asymmetric input formatting, so plan memory accordingly.',
     },
   };
 }
@@ -498,7 +498,7 @@ function parseArgs(argv: string[]): RunRetrievalBenchmarkOptions {
     else if (arg === '--allow-downloads') options.allowDownloads = true;
     else if (arg === '--help' || arg === '-h') {
       process.stderr.write(
-        'Usage: node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/retrieval-benchmark.ts [--mock|--real] [--top-k N] [--models id,id] [--allow-downloads]\n',
+        'Usage: node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/retrieval-benchmark.ts [--mock|--real] [--top-k N] [--models id,id] [--allow-downloads]\n\n--allow-downloads permits Codegraph GGUF hf: cache downloads only; transformer lanes follow @huggingface/transformers cache/network environment settings. Real Qwen/GGUF runs use separate document/query ports for asymmetric input formatting, so plan memory accordingly.\n',
       );
       process.exit(0);
     }

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -1,10 +1,33 @@
 import path from 'node:path';
 import {
   buildEmbeddings,
+  DEFAULT_MODEL,
   EMBEDDING_STRATEGIES,
+  MODELS,
   resolveModelRoleUri,
 } from '../../domain/search/index.js';
+import { warn } from '../../infrastructure/logger.js';
 import type { CommandDefinition } from '../types.js';
+
+function isLegacyEmbeddingModel(model: string): boolean {
+  return MODELS[model] != null || Object.values(MODELS).some((config) => config.name === model);
+}
+
+function resolveEmbedCommandModel(
+  explicitModel: string | undefined,
+  config: Parameters<typeof resolveModelRoleUri>[0],
+): string {
+  if (explicitModel) return explicitModel;
+
+  const roleModel = resolveModelRoleUri(config, 'embed');
+  if (isLegacyEmbeddingModel(roleModel)) return roleModel;
+
+  const legacyModel = config?.embeddings?.model || DEFAULT_MODEL;
+  warn(
+    `Embed role resolved to unsupported model "${roleModel}" for the current transformer runtime; using legacy embedding model "${legacyModel}".`,
+  );
+  return legacyModel;
+}
 
 export const command: CommandDefinition = {
   name: 'embed [dir]',
@@ -29,7 +52,7 @@ export const command: CommandDefinition = {
   },
   async execute([dir], opts, ctx) {
     const root = path.resolve(dir || '.');
-    const model = (opts.model as string) || resolveModelRoleUri(ctx.config, 'embed');
+    const model = resolveEmbedCommandModel(opts.model as string | undefined, ctx.config);
     await buildEmbeddings(root, model, opts.db as string | undefined, { strategy: opts.strategy });
   },
 };

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
-import { buildEmbeddings, DEFAULT_MODEL, EMBEDDING_STRATEGIES } from '../../domain/search/index.js';
+import {
+  buildEmbeddings,
+  EMBEDDING_STRATEGIES,
+  resolveModelRoleUri,
+} from '../../domain/search/index.js';
 import type { CommandDefinition } from '../types.js';
 
 export const command: CommandDefinition = {
@@ -25,8 +29,7 @@ export const command: CommandDefinition = {
   },
   async execute([dir], opts, ctx) {
     const root = path.resolve(dir || '.');
-    const embeddingsConfig = ctx.config.embeddings;
-    const model = (opts.model as string) || (embeddingsConfig?.model as string) || DEFAULT_MODEL;
+    const model = (opts.model as string) || resolveModelRoleUri(ctx.config, 'embed');
     await buildEmbeddings(root, model, opts.db as string | undefined, { strategy: opts.strategy });
   },
 };

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { isHttpModelUri } from '../../domain/search/http-embedding.js';
 import {
   buildEmbeddings,
   DEFAULT_MODEL,
@@ -6,11 +7,17 @@ import {
   MODELS,
   resolveModelRoleUri,
 } from '../../domain/search/index.js';
+import { isGgufModelUri } from '../../domain/search/model-cache.js';
 import { warn } from '../../infrastructure/logger.js';
 import type { CommandDefinition } from '../types.js';
 
-function isLegacyEmbeddingModel(model: string): boolean {
-  return MODELS[model] != null || Object.values(MODELS).some((config) => config.name === model);
+function isSupportedEmbeddingModel(model: string): boolean {
+  return (
+    MODELS[model] != null ||
+    Object.values(MODELS).some((config) => config.name === model) ||
+    isHttpModelUri(model) ||
+    isGgufModelUri(model)
+  );
 }
 
 function resolveEmbedCommandModel(
@@ -20,7 +27,7 @@ function resolveEmbedCommandModel(
   if (explicitModel) return explicitModel;
 
   const roleModel = resolveModelRoleUri(config, 'embed');
-  if (isLegacyEmbeddingModel(roleModel)) return roleModel;
+  if (isSupportedEmbeddingModel(roleModel)) return roleModel;
 
   const legacyModel = config?.embeddings?.model || DEFAULT_MODEL;
   warn(

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -43,7 +43,7 @@ export const command: CommandDefinition = {
   options: [
     [
       '-m, --model <name>',
-      'Embedding model (default from config or minilm). Run `codegraph models` for details',
+      'Embedding model (default from config: GNO/Qwen compact GGUF). Run `codegraph models` for details',
     ],
     [
       '-s, --strategy <name>',

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -31,7 +31,7 @@ function resolveEmbedCommandModel(
 
   const legacyModel = config?.embeddings?.model || DEFAULT_MODEL;
   warn(
-    `Embed role resolved to unsupported model "${roleModel}" for the current transformer runtime; using legacy embedding model "${legacyModel}".`,
+    `Embed role resolved to unsupported embedding model "${roleModel}"; using configured embedding model "${legacyModel}" instead.`,
   );
   return legacyModel;
 }

--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -1,12 +1,10 @@
-import { DEFAULT_MODEL, MODELS, resolveModelRoleUri } from '../../domain/search/index.js';
+import { MODELS, resolveModelRoleUri } from '../../domain/search/index.js';
 import type { CommandDefinition } from '../types.js';
 
 export const command: CommandDefinition = {
   name: 'models',
   description: 'List available embedding models',
   execute(_args, _opts, ctx) {
-    const embeddingsConfig = ctx.config.embeddings;
-    const defaultModel = (embeddingsConfig?.model as string) || DEFAULT_MODEL;
     const defaultRoleModel = resolveModelRoleUri(ctx.config, 'embed');
     console.log('\nAvailable embedding models:\n');
 
@@ -19,14 +17,15 @@ export const command: CommandDefinition = {
 
     for (const [key, cfg] of Object.entries(MODELS)) {
       const modelCfg = cfg as ModelEntry;
-      const def = key === defaultModel || modelCfg.name === defaultRoleModel ? ' (default)' : '';
+      const def =
+        key === defaultRoleModel || modelCfg.name === defaultRoleModel ? ' (default)' : '';
       const ctxWindow = modelCfg.contextWindow ? `${modelCfg.contextWindow} ctx` : '';
       console.log(
         `  ${key.padEnd(12)} ${String(modelCfg.dim).padStart(4)}d  ${ctxWindow.padEnd(9)} ${modelCfg.desc}${def}`,
       );
     }
     if (
-      !MODELS[defaultModel] &&
+      !MODELS[defaultRoleModel] &&
       !Object.values(MODELS).some((cfg) => cfg.name === defaultRoleModel)
     ) {
       console.log(`\nDefault embedding role: ${defaultRoleModel}`);

--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MODEL, MODELS } from '../../domain/search/index.js';
+import { DEFAULT_MODEL, MODELS, resolveModelRoleUri } from '../../domain/search/index.js';
 import type { CommandDefinition } from '../types.js';
 
 export const command: CommandDefinition = {
@@ -7,23 +7,31 @@ export const command: CommandDefinition = {
   execute(_args, _opts, ctx) {
     const embeddingsConfig = ctx.config.embeddings;
     const defaultModel = (embeddingsConfig?.model as string) || DEFAULT_MODEL;
+    const defaultRoleModel = resolveModelRoleUri(ctx.config, 'embed');
     console.log('\nAvailable embedding models:\n');
 
     interface ModelEntry {
       dim: number;
       desc: string;
       contextWindow?: number;
+      name: string;
     }
 
     for (const [key, cfg] of Object.entries(MODELS)) {
-      const def = key === defaultModel ? ' (default)' : '';
       const modelCfg = cfg as ModelEntry;
+      const def = key === defaultModel || modelCfg.name === defaultRoleModel ? ' (default)' : '';
       const ctxWindow = modelCfg.contextWindow ? `${modelCfg.contextWindow} ctx` : '';
       console.log(
         `  ${key.padEnd(12)} ${String(modelCfg.dim).padStart(4)}d  ${ctxWindow.padEnd(9)} ${modelCfg.desc}${def}`,
       );
     }
-    console.log('\nUsage: codegraph embed --model <name> --strategy <structured|source>');
-    console.log('       codegraph search "query" --model <name>\n');
+    if (
+      !MODELS[defaultModel] &&
+      !Object.values(MODELS).some((cfg) => cfg.name === defaultRoleModel)
+    ) {
+      console.log(`\nDefault embedding role: ${defaultRoleModel}`);
+    }
+    console.log('\nUsage: codegraph embed --model <name-or-uri> --strategy <structured|source>');
+    console.log('       codegraph search "query" --model <name-or-uri>\n');
   },
 };

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -28,6 +28,7 @@ export const command: CommandDefinition = {
       collectFile,
     ],
     ['-j, --json', 'Output as JSON'],
+    ['--explain', 'Include weighted RRF source contribution metadata'],
     ['--offset <number>', 'Skip N results (default: 0)'],
     ['--ndjson', 'Newline-delimited JSON output'],
   ],
@@ -63,6 +64,7 @@ export const command: CommandDefinition = {
       queryModes: normalized.queryModes,
       queryTextKind: normalized.queryTextKind,
       json: opts.json as boolean | undefined,
+      explain: opts.explain as boolean | undefined,
     });
   },
 };

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -61,6 +61,7 @@ export const command: CommandDefinition = {
       mode: opts.mode as 'hybrid' | 'semantic' | 'keyword' | undefined,
       expand: hasStructuredModes ? false : (opts.expand as boolean | undefined),
       queryModes: normalized.queryModes,
+      queryTextKind: normalized.queryTextKind,
       json: opts.json as boolean | undefined,
     });
   },

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -1,5 +1,5 @@
 import { collectFile } from '../../db/query-builder.js';
-import { search } from '../../domain/search/index.js';
+import { resolveModelRoleUri, search } from '../../domain/search/index.js';
 import type { CommandDefinition } from '../types.js';
 
 export const command: CommandDefinition = {
@@ -34,7 +34,7 @@ export const command: CommandDefinition = {
       limit: parseInt(opts.limit as string, 10),
       noTests: ctx.resolveNoTests(opts),
       minScore: parseFloat(opts.minScore as string),
-      model: opts.model as string | undefined,
+      model: (opts.model as string | undefined) || resolveModelRoleUri(ctx.config, 'embed'),
       kind: opts.kind as string | undefined,
       filePattern,
       rrfK: parseInt(opts.rrfK as string, 10),

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -1,5 +1,9 @@
 import { collectFile } from '../../db/query-builder.js';
 import { search } from '../../domain/search/index.js';
+import {
+  normalizeStructuredQueryInput,
+  parseQueryModeSpecs,
+} from '../../domain/search/search/expansion.js';
 import type { CommandDefinition } from '../types.js';
 
 export const command: CommandDefinition = {
@@ -18,6 +22,11 @@ export const command: CommandDefinition = {
     ['--mode <mode>', 'Search mode: hybrid, semantic, keyword (default: hybrid)'],
     ['--expand', 'Enable query expansion for hybrid search'],
     ['--no-expand', 'Disable query expansion for hybrid search'],
+    [
+      '--query-mode <mode:text>',
+      'Structured query mode (repeatable): term:<text>, intent:<text>, or hyde:<text>',
+      collectFile,
+    ],
     ['-j, --json', 'Output as JSON'],
     ['--offset <number>', 'Skip N results (default: 0)'],
     ['--ndjson', 'Newline-delimited JSON output'],
@@ -27,12 +36,21 @@ export const command: CommandDefinition = {
     if (opts.mode && !validModes.includes(opts.mode as string)) {
       return `Invalid mode "${opts.mode}". Valid: ${validModes.join(', ')}`;
     }
+    try {
+      const explicitModes = parseQueryModeSpecs((opts.queryMode || []) as string[]);
+      normalizeStructuredQueryInput(_query || '', explicitModes);
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
   },
   async execute([query], opts, ctx) {
     const fileArr = (opts.file || []) as string[];
     const filePattern =
       fileArr.length === 1 ? fileArr[0] : fileArr.length > 1 ? fileArr : undefined;
-    await search(query!, opts.db as string | undefined, {
+    const explicitModes = parseQueryModeSpecs((opts.queryMode || []) as string[]);
+    const normalized = normalizeStructuredQueryInput(query!, explicitModes);
+    const hasStructuredModes = normalized.queryModes.length > 0;
+    await search(normalized.query, opts.db as string | undefined, {
       limit: parseInt(opts.limit as string, 10),
       noTests: ctx.resolveNoTests(opts),
       minScore: parseFloat(opts.minScore as string),
@@ -41,7 +59,8 @@ export const command: CommandDefinition = {
       filePattern,
       rrfK: parseInt(opts.rrfK as string, 10),
       mode: opts.mode as 'hybrid' | 'semantic' | 'keyword' | undefined,
-      expand: opts.expand as boolean | undefined,
+      expand: hasStructuredModes ? false : (opts.expand as boolean | undefined),
+      queryModes: normalized.queryModes,
       json: opts.json as boolean | undefined,
     });
   },

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -16,6 +16,8 @@ export const command: CommandDefinition = {
     ['--file <pattern>', 'Filter by file path pattern (repeatable)', collectFile],
     ['--rrf-k <number>', 'RRF k parameter for multi-query ranking', '60'],
     ['--mode <mode>', 'Search mode: hybrid, semantic, keyword (default: hybrid)'],
+    ['--expand', 'Enable query expansion for hybrid search'],
+    ['--no-expand', 'Disable query expansion for hybrid search'],
     ['-j, --json', 'Output as JSON'],
     ['--offset <number>', 'Skip N results (default: 0)'],
     ['--ndjson', 'Newline-delimited JSON output'],
@@ -39,6 +41,7 @@ export const command: CommandDefinition = {
       filePattern,
       rrfK: parseInt(opts.rrfK as string, 10),
       mode: opts.mode as 'hybrid' | 'semantic' | 'keyword' | undefined,
+      expand: opts.expand as boolean | undefined,
       json: opts.json as boolean | undefined,
     });
   },

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -1,5 +1,5 @@
 import { collectFile } from '../../db/query-builder.js';
-import { resolveModelRoleUri, search } from '../../domain/search/index.js';
+import { search } from '../../domain/search/index.js';
 import type { CommandDefinition } from '../types.js';
 
 export const command: CommandDefinition = {
@@ -34,7 +34,7 @@ export const command: CommandDefinition = {
       limit: parseInt(opts.limit as string, 10),
       noTests: ctx.resolveNoTests(opts),
       minScore: parseFloat(opts.minScore as string),
-      model: (opts.model as string | undefined) || resolveModelRoleUri(ctx.config, 'embed'),
+      model: opts.model as string | undefined,
       kind: opts.kind as string | undefined,
       filePattern,
       rrfK: parseInt(opts.rrfK as string, 10),

--- a/src/domain/search/compatibility.ts
+++ b/src/domain/search/compatibility.ts
@@ -1,0 +1,53 @@
+export type EmbeddingInputType = 'query' | 'document';
+export type EmbeddingQueryFormat = 'raw-text' | 'qwen-instruct';
+export type EmbeddingDocumentFormat = 'raw-text';
+
+export interface EmbeddingCompatibilityProfile {
+  id: string;
+  queryFormat: EmbeddingQueryFormat;
+  documentFormat: EmbeddingDocumentFormat;
+}
+
+const DEFAULT_PROFILE: EmbeddingCompatibilityProfile = {
+  id: 'default',
+  queryFormat: 'raw-text',
+  documentFormat: 'raw-text',
+};
+
+const QWEN_PROFILE: EmbeddingCompatibilityProfile = {
+  id: 'qwen-embedding',
+  queryFormat: 'qwen-instruct',
+  documentFormat: 'raw-text',
+};
+
+function hasAllTerms(value: string, terms: string[]): boolean {
+  return terms.every((term) => value.includes(term));
+}
+
+export function getEmbeddingCompatibilityProfile(modelUri?: string): EmbeddingCompatibilityProfile {
+  const normalized = modelUri?.toLowerCase() ?? '';
+  if (hasAllTerms(normalized, ['qwen', 'embed'])) return QWEN_PROFILE;
+  return DEFAULT_PROFILE;
+}
+
+export function formatEmbeddingQuery(query: string, modelUri?: string): string {
+  const profile = getEmbeddingCompatibilityProfile(modelUri);
+  if (profile.queryFormat === 'qwen-instruct') {
+    return `Instruct: Given a code search query, retrieve relevant code symbols and implementation details.\nQuery: ${query}`;
+  }
+  return query;
+}
+
+export function formatEmbeddingDocument(text: string, _modelUri?: string): string {
+  return text;
+}
+
+export function formatEmbeddingText(
+  text: string,
+  modelUri: string | undefined,
+  inputType: EmbeddingInputType,
+): string {
+  return inputType === 'query'
+    ? formatEmbeddingQuery(text, modelUri)
+    : formatEmbeddingDocument(text, modelUri);
+}

--- a/src/domain/search/embedding-factory.ts
+++ b/src/domain/search/embedding-factory.ts
@@ -1,0 +1,163 @@
+import { EngineError } from '../../shared/errors.js';
+import { type EmbeddingInputType, formatEmbeddingText } from './compatibility.js';
+import { HttpEmbeddingPort, isHttpModelUri } from './http-embedding.js';
+import {
+  type DownloadPolicy,
+  isGgufModelUri,
+  ModelCache,
+  resolveDownloadPolicy,
+} from './model-cache.js';
+import { createTransformerEmbeddingPort, MODELS, resolveModelKey } from './models.js';
+import type { EmbeddingPort } from './ports.js';
+
+export interface EmbeddingPortFactoryOptions {
+  inputType?: EmbeddingInputType | 'raw';
+  cache?: ModelCache;
+  cacheDir?: string;
+  policy?: DownloadPolicy;
+  runtimeLoader?: () => Promise<unknown>;
+}
+
+class FormattingEmbeddingPort implements EmbeddingPort {
+  constructor(
+    private readonly inner: EmbeddingPort,
+    private readonly modelUri: string | undefined,
+    private readonly inputType: EmbeddingInputType,
+  ) {}
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    return this.inner.embedBatch(
+      texts.map((text) => formatEmbeddingText(text, this.modelUri, this.inputType)),
+    );
+  }
+
+  reset(): Promise<void> | void {
+    return this.inner.reset?.();
+  }
+}
+
+type LlamaEmbeddingContext = {
+  getEmbeddingFor(text: string): Promise<{ vector: Iterable<number> }>;
+};
+type LlamaEmbeddingModel = {
+  createEmbeddingContext(): Promise<LlamaEmbeddingContext>;
+  dispose?: () => Promise<void> | void;
+};
+
+function asError(cause: unknown): Error | undefined {
+  return cause instanceof Error
+    ? cause
+    : cause === undefined
+      ? undefined
+      : new Error(String(cause));
+}
+
+async function importOptionalRuntime(specifier: string): Promise<unknown> {
+  return (
+    new Function('specifier', 'return import(specifier)') as (value: string) => Promise<unknown>
+  )(specifier);
+}
+
+class NodeLlamaCppEmbeddingPort implements EmbeddingPort {
+  private context: LlamaEmbeddingContext | undefined;
+  private model: LlamaEmbeddingModel | undefined;
+
+  constructor(
+    private readonly runtimeLoader: () => Promise<unknown>,
+    private readonly modelPath: string,
+    private readonly modelUri: string,
+  ) {}
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    const context = await this.getContext();
+    const vectors: Float32Array[] = [];
+    for (const text of texts) {
+      const embedding = await context.getEmbeddingFor(text);
+      vectors.push(new Float32Array(Array.from(embedding.vector)));
+    }
+    return vectors;
+  }
+
+  async reset(): Promise<void> {
+    await this.model?.dispose?.();
+    this.model = undefined;
+    this.context = undefined;
+  }
+
+  private async getContext(): Promise<{
+    getEmbeddingFor(text: string): Promise<{ vector: Iterable<number> }>;
+  }> {
+    if (this.context) return this.context;
+    let runtime: unknown;
+    try {
+      runtime = await this.runtimeLoader();
+    } catch (cause) {
+      throw new EngineError(
+        'Qwen/GGUF embeddings require optional runtime node-llama-cpp. Install it only if you use GGUF models: npm install node-llama-cpp',
+        { cause: asError(cause) },
+      );
+    }
+    const mod = runtime as {
+      getLlama?: () => Promise<{
+        loadModel(args: { modelPath: string }): Promise<LlamaEmbeddingModel>;
+      }>;
+    };
+    if (!mod.getLlama) throw new EngineError('node-llama-cpp runtime is missing getLlama().');
+    const llama = await mod.getLlama();
+    this.model = await llama.loadModel({ modelPath: this.modelPath });
+    this.context = await this.model.createEmbeddingContext();
+    if (!this.context?.getEmbeddingFor) {
+      throw new EngineError(
+        `node-llama-cpp could not create an embedding context for ${this.modelUri}.`,
+      );
+    }
+    return this.context;
+  }
+}
+
+function isTransformerModel(modelUri: string): boolean {
+  const key = resolveModelKey(modelUri);
+  return MODELS[key] != null;
+}
+
+export async function createEmbeddingPort(
+  modelUri: string,
+  options: EmbeddingPortFactoryOptions = {},
+): Promise<EmbeddingPort> {
+  const inputType = options.inputType ?? 'document';
+  let port: EmbeddingPort;
+
+  if (isHttpModelUri(modelUri)) {
+    port = new HttpEmbeddingPort(modelUri);
+  } else if (isTransformerModel(modelUri)) {
+    port = createTransformerEmbeddingPort(modelUri);
+  } else if (isGgufModelUri(modelUri)) {
+    const cache = options.cache ?? new ModelCache(options.cacheDir);
+    const modelPath = await cache.ensureModel(
+      modelUri,
+      'embed',
+      options.policy ?? resolveDownloadPolicy(),
+    );
+    port = new NodeLlamaCppEmbeddingPort(
+      options.runtimeLoader ?? (() => importOptionalRuntime('node-llama-cpp')),
+      modelPath,
+      modelUri,
+    );
+  } else {
+    throw new EngineError(
+      `Unsupported embedding model "${modelUri}". Use a Codegraph transformer model, an OpenAI-compatible http(s) endpoint, hf: URI, or file: URI.`,
+    );
+  }
+
+  return inputType === 'raw' ? port : new FormattingEmbeddingPort(port, modelUri, inputType);
+}
+
+export async function embedTexts(
+  texts: string[],
+  modelUri: string,
+  inputType: EmbeddingInputType,
+): Promise<{ vectors: Float32Array[]; dim: number }> {
+  const port = await createEmbeddingPort(modelUri, { inputType });
+  const vectors = await port.embedBatch(texts);
+  return { vectors, dim: vectors[0]?.length ?? 0 };
+}

--- a/src/domain/search/embedding-factory.ts
+++ b/src/domain/search/embedding-factory.ts
@@ -19,11 +19,15 @@ export interface EmbeddingPortFactoryOptions {
 }
 
 class FormattingEmbeddingPort implements EmbeddingPort {
-  constructor(
-    private readonly inner: EmbeddingPort,
-    private readonly modelUri: string | undefined,
-    private readonly inputType: EmbeddingInputType,
-  ) {}
+  private readonly inner: EmbeddingPort;
+  private readonly modelUri: string | undefined;
+  private readonly inputType: EmbeddingInputType;
+
+  constructor(inner: EmbeddingPort, modelUri: string | undefined, inputType: EmbeddingInputType) {
+    this.inner = inner;
+    this.modelUri = modelUri;
+    this.inputType = inputType;
+  }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
     return this.inner.embedBatch(
@@ -59,14 +63,17 @@ async function importOptionalRuntime(specifier: string): Promise<unknown> {
 }
 
 class NodeLlamaCppEmbeddingPort implements EmbeddingPort {
+  private readonly runtimeLoader: () => Promise<unknown>;
+  private readonly modelPath: string;
+  private readonly modelUri: string;
   private context: LlamaEmbeddingContext | undefined;
   private model: LlamaEmbeddingModel | undefined;
 
-  constructor(
-    private readonly runtimeLoader: () => Promise<unknown>,
-    private readonly modelPath: string,
-    private readonly modelUri: string,
-  ) {}
+  constructor(runtimeLoader: () => Promise<unknown>, modelPath: string, modelUri: string) {
+    this.runtimeLoader = runtimeLoader;
+    this.modelPath = modelPath;
+    this.modelUri = modelUri;
+  }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
     const context = await this.getContext();

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -4,7 +4,9 @@ import { closeDb, findDbPath, getBuildMeta, openDb } from '../../db/index.js';
 import { warn } from '../../infrastructure/logger.js';
 import { DbError } from '../../shared/errors.js';
 import type { BetterSqlite3Database, NodeRow } from '../../types.js';
-import { embed, getModelConfig } from './models.js';
+import { formatEmbeddingDocument } from './compatibility.js';
+import { createEmbeddingPort } from './embedding-factory.js';
+import { getEmbeddingModelConfig } from './models.js';
 import { type EmbeddingPort, embedWithRecovery } from './ports.js';
 import { buildSourceText } from './strategies/source.js';
 import { buildStructuredText } from './strategies/structured.js';
@@ -112,7 +114,7 @@ export async function buildEmbeddings(
   const nodeIds: number[] = [];
   const nodeNames: string[] = [];
   const previews: string[] = [];
-  const config = getModelConfig(modelKey);
+  const config = getEmbeddingModelConfig(modelKey);
   const contextWindow = config.contextWindow;
   let overflowCount = 0;
   let filesRead = 0;
@@ -144,7 +146,7 @@ export async function buildEmbeddings(
         text = text.slice(0, maxChars);
       }
 
-      texts.push(text);
+      texts.push(formatEmbeddingDocument(text, modelKey));
       nodeIds.push(node.id);
       nodeNames.push(node.name);
       previews.push(`${node.name} (${node.kind}) -- ${file}:${node.line}`);
@@ -171,12 +173,17 @@ export async function buildEmbeddings(
   }
 
   console.log(`Embedding ${texts.length} symbols...`);
+  const embeddingPort =
+    options.embeddingPort ?? (await createEmbeddingPort(modelKey, { inputType: 'raw' }));
   const embedded = options.embeddingPort
     ? {
-        vectors: await embedWithRecovery(options.embeddingPort, texts),
+        vectors: await embedWithRecovery(embeddingPort, texts),
         dim: texts.length > 0 ? undefined : config.dim,
       }
-    : await embed(texts, modelKey);
+    : {
+        vectors: await embedWithRecovery(embeddingPort, texts),
+        dim: texts.length > 0 ? undefined : config.dim,
+      };
   const vectors = embedded.vectors;
   const dim = embedded.dim ?? vectors[0]?.length ?? config.dim;
 

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -250,9 +250,9 @@ export async function buildEmbeddings(
   );
   if (!vectorWrite.ok) {
     warn(vectorWrite.error.message);
-  } else if (vectorIndex.vecDirty) {
-    const sync = vectorIndex.syncVecIndex();
-    if (!sync.ok) warn(sync.error.message);
+  } else {
+    const rebuild = vectorIndex.rebuildVecIndex();
+    if (!rebuild.ok) warn(rebuild.error.message);
   }
 
   console.log(

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -207,6 +207,7 @@ export async function buildEmbeddings(
   });
   const vectorIndex = createVectorIndex(db, activeMetadata);
   const metadataKey = vectorStorageKey(activeMetadata);
+  vectorIndex.vecDirty = true;
   db.prepare('DELETE FROM embedding_vectors WHERE metadata_key = ?').run(metadataKey);
 
   const insert = db.prepare(

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -6,7 +6,7 @@ import { DbError } from '../../shared/errors.js';
 import type { BetterSqlite3Database, NodeRow } from '../../types.js';
 import { formatEmbeddingDocument } from './compatibility.js';
 import { createEmbeddingPort } from './embedding-factory.js';
-import { getEmbeddingModelConfig } from './models.js';
+import { getEmbeddingBatchSize, getEmbeddingModelConfig } from './models.js';
 import { type EmbeddingPort, embedWithRecovery } from './ports.js';
 import { buildSourceText } from './strategies/source.js';
 import { buildStructuredText } from './strategies/structured.js';
@@ -175,15 +175,11 @@ export async function buildEmbeddings(
   console.log(`Embedding ${texts.length} symbols...`);
   const embeddingPort =
     options.embeddingPort ?? (await createEmbeddingPort(modelKey, { inputType: 'raw' }));
-  const embedded = options.embeddingPort
-    ? {
-        vectors: await embedWithRecovery(embeddingPort, texts),
-        dim: texts.length > 0 ? undefined : config.dim,
-      }
-    : {
-        vectors: await embedWithRecovery(embeddingPort, texts),
-        dim: texts.length > 0 ? undefined : config.dim,
-      };
+  const batchSize = getEmbeddingBatchSize(modelKey);
+  const embedded = {
+    vectors: await embedWithRecovery(embeddingPort, texts, { batchSize }),
+    dim: texts.length > 0 ? undefined : config.dim,
+  };
   const vectors = embedded.vectors;
   const dim = embedded.dim ?? vectors[0]?.length ?? config.dim;
 

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -5,6 +5,7 @@ import { warn } from '../../infrastructure/logger.js';
 import { DbError } from '../../shared/errors.js';
 import type { BetterSqlite3Database, NodeRow } from '../../types.js';
 import { embed, getModelConfig } from './models.js';
+import { type EmbeddingPort, embedWithRecovery } from './ports.js';
 import { buildSourceText } from './strategies/source.js';
 import { buildStructuredText } from './strategies/structured.js';
 
@@ -49,6 +50,7 @@ function initEmbeddingsSchema(db: BetterSqlite3Database): void {
 
 export interface BuildEmbeddingsOptions {
   strategy?: 'structured' | 'source';
+  embeddingPort?: EmbeddingPort;
 }
 
 /**
@@ -169,7 +171,14 @@ export async function buildEmbeddings(
   }
 
   console.log(`Embedding ${texts.length} symbols...`);
-  const { vectors, dim } = await embed(texts, modelKey);
+  const embedded = options.embeddingPort
+    ? {
+        vectors: await embedWithRecovery(options.embeddingPort, texts),
+        dim: texts.length > 0 ? undefined : config.dim,
+      }
+    : await embed(texts, modelKey);
+  const vectors = embedded.vectors;
+  const dim = embedded.dim ?? vectors[0]?.length ?? config.dim;
 
   const insert = db.prepare(
     'INSERT OR REPLACE INTO embeddings (node_id, vector, text_preview, full_text) VALUES (?, ?, ?, ?)',

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -6,6 +6,12 @@ import { DbError } from '../../shared/errors.js';
 import type { BetterSqlite3Database, NodeRow } from '../../types.js';
 import { formatEmbeddingDocument } from './compatibility.js';
 import { createEmbeddingPort } from './embedding-factory.js';
+import {
+  createEmbeddingMetadataEntries,
+  expectedEmbeddingMetadata,
+  readEmbeddingMetadata,
+  warnIfEmbeddingMetadataStale,
+} from './metadata.js';
 import { getEmbeddingBatchSize, getEmbeddingModelConfig } from './models.js';
 import { type EmbeddingPort, embedWithRecovery } from './ports.js';
 import { buildSourceText } from './strategies/source.js';
@@ -77,6 +83,17 @@ export async function buildEmbeddings(
   const db = openDb(dbPath) as BetterSqlite3Database;
   initEmbeddingsSchema(db);
 
+  const config = getEmbeddingModelConfig(modelKey);
+  warnIfEmbeddingMetadataStale(
+    readEmbeddingMetadata(db),
+    expectedEmbeddingMetadata({
+      modelUri: config.name,
+      dimension: config.dim || undefined,
+      strategy,
+    }),
+    { modelHint: modelKey, command: 'embed' },
+  );
+
   // Prefer the repo root recorded at build time — embed may be invoked from a
   // different cwd (e.g. `codegraph embed --db /abs/path/graph.db`) and the
   // positional rootDir will be wrong in that case. For legacy DBs without
@@ -114,7 +131,6 @@ export async function buildEmbeddings(
   const nodeIds: number[] = [];
   const nodeNames: string[] = [];
   const previews: string[] = [];
-  const config = getEmbeddingModelConfig(modelKey);
   const contextWindow = config.contextWindow;
   let overflowCount = 0;
   let filesRead = 0;
@@ -199,12 +215,15 @@ export async function buildEmbeddings(
       );
       insertFts.run(nodeIds[i], nodeNames[i], texts[i]);
     }
-    insertMeta.run('model', config.name);
-    insertMeta.run('dim', String(dim));
+    for (const { key, value } of createEmbeddingMetadataEntries({
+      modelUri: config.name,
+      dimension: dim,
+      strategy,
+    })) {
+      insertMeta.run(key, value);
+    }
     insertMeta.run('count', String(vectors.length));
     insertMeta.run('fts_count', String(vectors.length));
-    insertMeta.run('strategy', strategy);
-    insertMeta.run('built_at', new Date().toISOString());
     if (overflowCount > 0) {
       insertMeta.run('truncated_count', String(overflowCount));
     }

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -188,7 +188,12 @@ export async function buildEmbeddings(
   const insertAll = db.transaction(() => {
     for (let i = 0; i < vectors.length; i++) {
       const vec = vectors[i] as Float32Array;
-      insert.run(nodeIds[i], Buffer.from(vec.buffer), previews[i], texts[i]);
+      insert.run(
+        nodeIds[i],
+        Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength),
+        previews[i],
+        texts[i],
+      );
       insertFts.run(nodeIds[i], nodeNames[i], texts[i]);
     }
     insertMeta.run('model', config.name);

--- a/src/domain/search/generator.ts
+++ b/src/domain/search/generator.ts
@@ -16,6 +16,7 @@ import { getEmbeddingBatchSize, getEmbeddingModelConfig } from './models.js';
 import { type EmbeddingPort, embedWithRecovery } from './ports.js';
 import { buildSourceText } from './strategies/source.js';
 import { buildStructuredText } from './strategies/structured.js';
+import { createVectorIndex, vectorStorageKey } from './vector-index.js';
 
 /**
  * Rough token estimate (~4 chars per token for code/English).
@@ -199,6 +200,15 @@ export async function buildEmbeddings(
   const vectors = embedded.vectors;
   const dim = embedded.dim ?? vectors[0]?.length ?? config.dim;
 
+  const activeMetadata = expectedEmbeddingMetadata({
+    modelUri: config.name,
+    dimension: dim,
+    strategy,
+  });
+  const vectorIndex = createVectorIndex(db, activeMetadata);
+  const metadataKey = vectorStorageKey(activeMetadata);
+  db.prepare('DELETE FROM embedding_vectors WHERE metadata_key = ?').run(metadataKey);
+
   const insert = db.prepare(
     'INSERT OR REPLACE INTO embeddings (node_id, vector, text_preview, full_text) VALUES (?, ?, ?, ?)',
   );
@@ -229,6 +239,21 @@ export async function buildEmbeddings(
     }
   });
   insertAll();
+
+  const vectorWrite = vectorIndex.upsertVectors(
+    vectors.map((vec, i) => ({
+      nodeId: nodeIds[i]!,
+      model: config.name,
+      metadataKey,
+      embedding: vec,
+    })),
+  );
+  if (!vectorWrite.ok) {
+    warn(vectorWrite.error.message);
+  } else if (vectorIndex.vecDirty) {
+    const sync = vectorIndex.syncVecIndex();
+    if (!sync.ok) warn(sync.error.message);
+  }
 
   console.log(
     `\nStored ${vectors.length} embeddings (${dim}d, ${config.name}, strategy: ${strategy}) in graph.db`,

--- a/src/domain/search/http-embedding.ts
+++ b/src/domain/search/http-embedding.ts
@@ -1,0 +1,77 @@
+import { EngineError } from '../../shared/errors.js';
+import type { EmbeddingPort } from './ports.js';
+
+function asError(cause: unknown): Error | undefined {
+  return cause instanceof Error
+    ? cause
+    : cause === undefined
+      ? undefined
+      : new Error(String(cause));
+}
+
+interface OpenAIEmbeddingResponse {
+  data?: Array<{ embedding?: unknown; index?: number }>;
+}
+
+export function isHttpModelUri(uri: string): boolean {
+  return uri.startsWith('http://') || uri.startsWith('https://');
+}
+
+export class HttpEmbeddingPort implements EmbeddingPort {
+  private readonly apiUrl: string;
+  private readonly modelName: string;
+
+  constructor(private readonly modelUri: string) {
+    const hashIndex = modelUri.indexOf('#');
+    if (hashIndex > 0) {
+      this.apiUrl = modelUri.slice(0, hashIndex);
+      this.modelName = modelUri.slice(hashIndex + 1);
+    } else {
+      this.apiUrl = modelUri;
+      const url = new URL(modelUri);
+      this.modelName = url.pathname.split('/').filter(Boolean).at(-1) || 'embedding-model';
+    }
+  }
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    let response: Response;
+    try {
+      response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input: texts, model: this.modelName }),
+      });
+    } catch (cause) {
+      throw new EngineError(`Embedding HTTP request failed for ${this.modelUri}.`, {
+        cause: asError(cause),
+      });
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new EngineError(
+        `Embedding HTTP endpoint ${this.apiUrl} returned HTTP ${response.status}${body ? `: ${body}` : ''}`,
+      );
+    }
+
+    const payload = (await response.json()) as OpenAIEmbeddingResponse;
+    const data = payload.data;
+    if (!Array.isArray(data)) {
+      throw new EngineError('Embedding HTTP response is invalid: missing data array.');
+    }
+    const sorted = [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    if (sorted.length !== texts.length) {
+      throw new EngineError(
+        `Embedding HTTP response returned ${sorted.length} vector(s) for ${texts.length} input(s).`,
+      );
+    }
+    return sorted.map((item, index) => {
+      if (!Array.isArray(item.embedding)) {
+        throw new EngineError(
+          `Embedding HTTP response is invalid: missing embedding at index ${index}.`,
+        );
+      }
+      return new Float32Array(item.embedding as number[]);
+    });
+  }
+}

--- a/src/domain/search/http-embedding.ts
+++ b/src/domain/search/http-embedding.ts
@@ -18,10 +18,12 @@ export function isHttpModelUri(uri: string): boolean {
 }
 
 export class HttpEmbeddingPort implements EmbeddingPort {
+  private readonly modelUri: string;
   private readonly apiUrl: string;
   private readonly modelName: string;
 
-  constructor(private readonly modelUri: string) {
+  constructor(modelUri: string) {
+    this.modelUri = modelUri;
     const hashIndex = modelUri.indexOf('#');
     if (hashIndex > 0) {
       this.apiUrl = modelUri.slice(0, hashIndex);

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -59,6 +59,7 @@ export type {
   ExpansionResult,
   QueryMode,
   QueryModeInput,
+  QueryTextKind,
   StructuredQueryNormalization,
 } from './search/expansion.js';
 export {

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -6,8 +6,25 @@
 
 export type { BuildEmbeddingsOptions } from './generator.js';
 export { buildEmbeddings, estimateTokens } from './generator.js';
-export type { ModelConfig } from './models.js';
-export { DEFAULT_MODEL, disposeModel, EMBEDDING_STRATEGIES, embed, MODELS } from './models.js';
+export type {
+  ModelConfig,
+  ModelRole,
+  ModelRoleMap,
+  ResolvedRetrievalModels,
+  RetrievalModelPreset,
+} from './models.js';
+export {
+  DEFAULT_MODEL,
+  DEFAULT_RETRIEVAL_PRESET,
+  disposeModel,
+  EMBEDDING_STRATEGIES,
+  embed,
+  MODELS,
+  RETRIEVAL_MODEL_PRESETS,
+  resolveModelKey,
+  resolveModelRoleUri,
+  resolveRetrievalModels,
+} from './models.js';
 export { search } from './search/cli-formatter.js';
 export { hybridSearchData } from './search/hybrid.js';
 export { ftsSearchData } from './search/keyword.js';

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -14,6 +14,7 @@ export type {
   RetrievalModelPreset,
 } from './models.js';
 export {
+  createTransformerEmbeddingPort,
   DEFAULT_MODEL,
   DEFAULT_RETRIEVAL_PRESET,
   disposeModel,
@@ -25,6 +26,8 @@ export {
   resolveModelRoleUri,
   resolveRetrievalModels,
 } from './models.js';
+export type { EmbeddingPort, EmbeddingRecoveryOptions } from './ports.js';
+export { embedWithRecovery } from './ports.js';
 export { search } from './search/cli-formatter.js';
 export { hybridSearchData } from './search/hybrid.js';
 export { ftsSearchData } from './search/keyword.js';

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -59,7 +59,6 @@ export {
   applyExpansionGuardrails,
   buildExpansionPrompt,
   expandOrFallback,
-  hasStrongBm25Signal,
   parseExpansionOutput,
   routeExpandedQueries,
 } from './search/expansion.js';

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -13,6 +13,15 @@ export { createEmbeddingPort, embedTexts } from './embedding-factory.js';
 export type { BuildEmbeddingsOptions } from './generator.js';
 export { buildEmbeddings, estimateTokens } from './generator.js';
 export { HttpEmbeddingPort, isHttpModelUri } from './http-embedding.js';
+export type { ActiveEmbeddingMetadata, EmbeddingMetadata } from './metadata.js';
+export {
+  createEmbeddingMetadataEntries,
+  diagnoseEmbeddingMetadata,
+  EMBEDDING_FORMATTER_VERSION,
+  expectedEmbeddingMetadata,
+  readEmbeddingMetadata,
+  warnIfEmbeddingMetadataStale,
+} from './metadata.js';
 export type { DownloadPolicy, ParsedModelUri } from './model-cache.js';
 export {
   isGgufModelUri,

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -35,6 +35,7 @@ export {
   disposeModel,
   EMBEDDING_STRATEGIES,
   embed,
+  getEmbeddingBatchSize,
   MODELS,
   RETRIEVAL_MODEL_PRESETS,
   resolveModelKey,

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -58,3 +58,17 @@ export { hybridSearchData } from './search/hybrid.js';
 export { ftsSearchData } from './search/keyword.js';
 export { multiSearchData, searchData } from './search/semantic.js';
 export { cosineSim } from './stores/sqlite-blob.js';
+export type {
+  VectorAccelerationDriver,
+  VectorIndex,
+  VectorRow,
+  VectorSearchResult,
+} from './vector-index.js';
+export {
+  createVectorIndex,
+  decodeEmbedding,
+  encodeEmbedding,
+  setVectorAccelerationDriverForTests,
+  vectorStorageKey,
+  vectorTableName,
+} from './vector-index.js';

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -39,12 +39,16 @@ export type {
 } from './models.js';
 export {
   createTransformerEmbeddingPort,
+  DEFAULT_EMBEDDING_MODEL,
   DEFAULT_MODEL,
   DEFAULT_RETRIEVAL_PRESET,
   disposeModel,
   EMBEDDING_STRATEGIES,
   embed,
+  GNO_COMPACT_EMBEDDING_MODEL,
   getEmbeddingBatchSize,
+  LEGACY_RETRIEVAL_PRESET,
+  LEGACY_TRANSFORMER_DEFAULT_MODEL,
   MODELS,
   RETRIEVAL_MODEL_PRESETS,
   resolveModelKey,

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -54,13 +54,24 @@ export {
 export type { EmbeddingPort, EmbeddingRecoveryOptions } from './ports.js';
 export { embedWithRecovery } from './ports.js';
 export { search } from './search/cli-formatter.js';
-export type { ExpansionProvider, ExpansionResult } from './search/expansion.js';
+export type {
+  ExpansionProvider,
+  ExpansionResult,
+  QueryMode,
+  QueryModeInput,
+  StructuredQueryNormalization,
+} from './search/expansion.js';
 export {
   applyExpansionGuardrails,
+  buildExpansionFromQueryModes,
   buildExpansionPrompt,
   expandOrFallback,
+  normalizeStructuredQueryInput,
   parseExpansionOutput,
+  parseQueryModeSpec,
+  parseQueryModeSpecs,
   routeExpandedQueries,
+  validateQueryModes,
 } from './search/expansion.js';
 export { hybridSearchData } from './search/hybrid.js';
 export { ftsSearchData } from './search/keyword.js';

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -54,6 +54,15 @@ export {
 export type { EmbeddingPort, EmbeddingRecoveryOptions } from './ports.js';
 export { embedWithRecovery } from './ports.js';
 export { search } from './search/cli-formatter.js';
+export type { ExpansionProvider, ExpansionResult } from './search/expansion.js';
+export {
+  applyExpansionGuardrails,
+  buildExpansionPrompt,
+  expandOrFallback,
+  hasStrongBm25Signal,
+  parseExpansionOutput,
+  routeExpandedQueries,
+} from './search/expansion.js';
 export { hybridSearchData } from './search/hybrid.js';
 export { ftsSearchData } from './search/keyword.js';
 export { multiSearchData, searchData } from './search/semantic.js';

--- a/src/domain/search/index.ts
+++ b/src/domain/search/index.ts
@@ -4,8 +4,23 @@
  * Re-exports everything consumers previously imported from `../embedder.js`.
  */
 
+export {
+  formatEmbeddingDocument,
+  formatEmbeddingQuery,
+  getEmbeddingCompatibilityProfile,
+} from './compatibility.js';
+export { createEmbeddingPort, embedTexts } from './embedding-factory.js';
 export type { BuildEmbeddingsOptions } from './generator.js';
 export { buildEmbeddings, estimateTokens } from './generator.js';
+export { HttpEmbeddingPort, isHttpModelUri } from './http-embedding.js';
+export type { DownloadPolicy, ParsedModelUri } from './model-cache.js';
+export {
+  isGgufModelUri,
+  ModelCache,
+  parseModelUri,
+  resolveDownloadPolicy,
+  validateGgufFile,
+} from './model-cache.js';
 export type {
   ModelConfig,
   ModelRole,

--- a/src/domain/search/metadata.ts
+++ b/src/domain/search/metadata.ts
@@ -1,0 +1,139 @@
+import { getEmbeddingMeta } from '../../db/repository/embeddings.js';
+import { warn } from '../../infrastructure/logger.js';
+import type { BetterSqlite3Database } from '../../types.js';
+import { getEmbeddingCompatibilityProfile } from './compatibility.js';
+
+export const EMBEDDING_FORMATTER_VERSION = 'codegraph-symbol-text-v1';
+
+export interface EmbeddingMetadata {
+  modelUri?: string;
+  dimension?: number;
+  strategy?: string;
+  compatibilityProfile?: string;
+  formatterVersion?: string;
+  builtAt?: string;
+  isLegacy: boolean;
+}
+
+export interface ActiveEmbeddingMetadata {
+  modelUri: string;
+  dimension?: number;
+  strategy?: string;
+  compatibilityProfile: string;
+  formatterVersion: string;
+}
+
+export interface EmbeddingMetadataEntry {
+  key: string;
+  value: string;
+}
+
+function parseDimension(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function readEmbeddingMetadata(db: BetterSqlite3Database): EmbeddingMetadata {
+  const modelUri = getEmbeddingMeta(db, 'model_uri') || getEmbeddingMeta(db, 'model');
+  const dimension = parseDimension(
+    getEmbeddingMeta(db, 'dimension') || getEmbeddingMeta(db, 'dim'),
+  );
+  const strategy = getEmbeddingMeta(db, 'strategy');
+  const compatibilityProfile = getEmbeddingMeta(db, 'compatibility_profile');
+  const formatterVersion = getEmbeddingMeta(db, 'formatter_version');
+  const builtAt = getEmbeddingMeta(db, 'build_timestamp') || getEmbeddingMeta(db, 'built_at');
+
+  return {
+    modelUri,
+    dimension,
+    strategy,
+    compatibilityProfile,
+    formatterVersion,
+    builtAt,
+    isLegacy: !getEmbeddingMeta(db, 'model_uri') || !compatibilityProfile || !formatterVersion,
+  };
+}
+
+export function createEmbeddingMetadataEntries(args: {
+  modelUri: string;
+  dimension: number;
+  strategy: string;
+  builtAt?: string;
+}): EmbeddingMetadataEntry[] {
+  const builtAt = args.builtAt ?? new Date().toISOString();
+  const compatibilityProfile = getEmbeddingCompatibilityProfile(args.modelUri).id;
+  return [
+    // Legacy keys kept for migration compatibility.
+    { key: 'model', value: args.modelUri },
+    { key: 'dim', value: String(args.dimension) },
+    { key: 'strategy', value: args.strategy },
+    { key: 'built_at', value: builtAt },
+    // Model-aware keys.
+    { key: 'model_uri', value: args.modelUri },
+    { key: 'dimension', value: String(args.dimension) },
+    { key: 'compatibility_profile', value: compatibilityProfile },
+    { key: 'formatter_version', value: EMBEDDING_FORMATTER_VERSION },
+    { key: 'build_timestamp', value: builtAt },
+  ];
+}
+
+export function expectedEmbeddingMetadata(args: {
+  modelUri: string;
+  dimension?: number;
+  strategy?: string;
+}): ActiveEmbeddingMetadata {
+  return {
+    modelUri: args.modelUri,
+    dimension: args.dimension,
+    strategy: args.strategy,
+    compatibilityProfile: getEmbeddingCompatibilityProfile(args.modelUri).id,
+    formatterVersion: EMBEDDING_FORMATTER_VERSION,
+  };
+}
+
+export function diagnoseEmbeddingMetadata(
+  stored: EmbeddingMetadata,
+  active: ActiveEmbeddingMetadata,
+): string[] {
+  const diagnostics: string[] = [];
+
+  if (stored.modelUri && stored.modelUri !== active.modelUri) {
+    diagnostics.push(`model URI is ${stored.modelUri}, active model URI is ${active.modelUri}`);
+  }
+  if (stored.dimension && active.dimension && stored.dimension !== active.dimension) {
+    diagnostics.push(`dimension is ${stored.dimension}, active dimension is ${active.dimension}`);
+  }
+  if (stored.strategy && active.strategy && stored.strategy !== active.strategy) {
+    diagnostics.push(`strategy is ${stored.strategy}, active strategy is ${active.strategy}`);
+  }
+  if (stored.compatibilityProfile && stored.compatibilityProfile !== active.compatibilityProfile) {
+    diagnostics.push(
+      `compatibility profile is ${stored.compatibilityProfile}, active profile is ${active.compatibilityProfile}`,
+    );
+  }
+  if (stored.formatterVersion && stored.formatterVersion !== active.formatterVersion) {
+    diagnostics.push(
+      `formatter version is ${stored.formatterVersion}, active formatter version is ${active.formatterVersion}`,
+    );
+  }
+
+  return diagnostics;
+}
+
+export function warnIfEmbeddingMetadataStale(
+  stored: EmbeddingMetadata,
+  active: ActiveEmbeddingMetadata,
+  options: { modelHint?: string; command?: 'search' | 'embed' } = {},
+): string[] {
+  const diagnostics = diagnoseEmbeddingMetadata(stored, active);
+  if (diagnostics.length === 0) return diagnostics;
+
+  const modelHint = options.modelHint ?? active.modelUri;
+  const strategyHint = active.strategy ? ` --strategy ${active.strategy}` : '';
+  warn(
+    `Stored embeddings may be stale or incompatible: ${diagnostics.join('; ')}. ` +
+      `Re-run \`codegraph embed --model ${modelHint}${strategyHint}\` with the active model/strategy/profile.`,
+  );
+  return diagnostics;
+}

--- a/src/domain/search/metadata.ts
+++ b/src/domain/search/metadata.ts
@@ -1,3 +1,4 @@
+import { getBuildMeta } from '../../db/index.js';
 import { getEmbeddingMeta } from '../../db/repository/embeddings.js';
 import { warn } from '../../infrastructure/logger.js';
 import type { BetterSqlite3Database } from '../../types.js';
@@ -12,6 +13,7 @@ export interface EmbeddingMetadata {
   compatibilityProfile?: string;
   formatterVersion?: string;
   builtAt?: string;
+  graphBuiltAt?: string;
   isLegacy: boolean;
 }
 
@@ -34,6 +36,12 @@ function parseDimension(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function parseTimestamp(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 export function readEmbeddingMetadata(db: BetterSqlite3Database): EmbeddingMetadata {
   const modelUri = getEmbeddingMeta(db, 'model_uri') || getEmbeddingMeta(db, 'model');
   const dimension = parseDimension(
@@ -43,6 +51,7 @@ export function readEmbeddingMetadata(db: BetterSqlite3Database): EmbeddingMetad
   const compatibilityProfile = getEmbeddingMeta(db, 'compatibility_profile');
   const formatterVersion = getEmbeddingMeta(db, 'formatter_version');
   const builtAt = getEmbeddingMeta(db, 'build_timestamp') || getEmbeddingMeta(db, 'built_at');
+  const graphBuiltAt = getBuildMeta(db, 'built_at') ?? undefined;
 
   return {
     modelUri,
@@ -51,6 +60,7 @@ export function readEmbeddingMetadata(db: BetterSqlite3Database): EmbeddingMetad
     compatibilityProfile,
     formatterVersion,
     builtAt,
+    graphBuiltAt,
     isLegacy: !getEmbeddingMeta(db, 'model_uri') || !compatibilityProfile || !formatterVersion,
   };
 }
@@ -115,6 +125,18 @@ export function diagnoseEmbeddingMetadata(
   if (stored.formatterVersion && stored.formatterVersion !== active.formatterVersion) {
     diagnostics.push(
       `formatter version is ${stored.formatterVersion}, active formatter version is ${active.formatterVersion}`,
+    );
+  }
+
+  const embeddingBuiltAt = parseTimestamp(stored.builtAt);
+  const graphBuiltAt = parseTimestamp(stored.graphBuiltAt);
+  if (
+    embeddingBuiltAt !== undefined &&
+    graphBuiltAt !== undefined &&
+    embeddingBuiltAt < graphBuiltAt
+  ) {
+    diagnostics.push(
+      `embedding build timestamp ${stored.builtAt} is older than graph build timestamp ${stored.graphBuiltAt}`,
     );
   }
 

--- a/src/domain/search/model-cache.ts
+++ b/src/domain/search/model-cache.ts
@@ -154,14 +154,19 @@ export class ModelCache {
 
     const cached = await this.getCachedPath(uri);
     if (cached) return cached;
+    const localFile = await this.findLocalCachedPath(parsed, uri);
+    if (localFile) {
+      await this.addToManifest(uri, type, localFile);
+      return localFile;
+    }
     if (policy.offline) {
       throw new EngineError(
-        `Model ${uri} is not cached and offline mode is enabled. Disable CODEGRAPH_OFFLINE/HF_HUB_OFFLINE or pre-download the model into ${this.dir}.`,
+        `Model ${uri} is not cached and offline mode is enabled. Add a Codegraph cache manifest entry at ${this.manifestPath}, place the GGUF file under ${this.dir}/<org>/<repo>/<file>, or disable CODEGRAPH_OFFLINE/HF_HUB_OFFLINE.`,
       );
     }
     if (!policy.allowDownload) {
       throw new EngineError(
-        `Model ${uri} is not cached and automatic downloads are disabled. Set CODEGRAPH_NO_AUTO_DOWNLOAD=0 or pre-download the model into ${this.dir}.`,
+        `Model ${uri} is not cached and automatic downloads are disabled. Add a Codegraph cache manifest entry at ${this.manifestPath}, place the GGUF file under ${this.dir}/<org>/<repo>/<file>, or set CODEGRAPH_NO_AUTO_DOWNLOAD=0.`,
       );
     }
 
@@ -202,6 +207,24 @@ export class ModelCache {
       await this.removeFromManifest(uri);
       return null;
     }
+  }
+
+  private async findLocalCachedPath(parsed: ParsedModelUri, uri: string): Promise<string | null> {
+    if (parsed.scheme !== 'hf' || parsed.quantization || !parsed.file) return null;
+    const candidates = [
+      path.join(this.dir, parsed.org, parsed.repo, parsed.file),
+      path.join(this.dir, parsed.repo, parsed.file),
+      path.join(this.dir, parsed.file),
+    ];
+    for (const candidate of candidates) {
+      try {
+        await validateGgufFile(candidate, uri);
+        return candidate;
+      } catch {
+        // Continue looking for deterministic local cache layouts before reporting a miss.
+      }
+    }
+    return null;
   }
 
   private async loadManifest(): Promise<Manifest> {

--- a/src/domain/search/model-cache.ts
+++ b/src/domain/search/model-cache.ts
@@ -1,0 +1,247 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { EngineError } from '../../shared/errors.js';
+
+export type ModelType = 'embed' | 'rerank' | 'expand' | 'gen';
+export interface DownloadPolicy {
+  offline: boolean;
+  allowDownload: boolean;
+}
+export interface PolicyFlags {
+  offline?: boolean;
+  allowDownload?: boolean;
+}
+export type ParsedModelUri =
+  | { scheme: 'hf'; org: string; repo: string; file: string; quantization?: string }
+  | { scheme: 'file'; file: string };
+
+interface ManifestEntry {
+  uri: string;
+  type: ModelType;
+  path: string;
+  cachedAt: string;
+}
+interface Manifest {
+  version: '1.0';
+  models: ManifestEntry[];
+}
+
+const HF_QUANT_PATTERN = /^([^/]+)\/([^/:]+):(\w+)$/;
+const HF_PATH_PATTERN = /^([^/]+)\/([^/]+)\/(.+\.gguf)$/i;
+const GGUF_MAGIC = new Uint8Array([0x47, 0x47, 0x55, 0x46]);
+
+function asError(cause: unknown): Error | undefined {
+  return cause instanceof Error
+    ? cause
+    : cause === undefined
+      ? undefined
+      : new Error(String(cause));
+}
+
+async function importOptionalRuntime(specifier: string): Promise<unknown> {
+  return (
+    new Function('specifier', 'return import(specifier)') as (value: string) => Promise<unknown>
+  )(specifier);
+}
+
+export function resolveDownloadPolicy(
+  env: Record<string, string | undefined> = process.env,
+  flags: PolicyFlags = {},
+): DownloadPolicy {
+  if (flags.offline || truthy(env.HF_HUB_OFFLINE) || truthy(env.CODEGRAPH_OFFLINE)) {
+    return { offline: true, allowDownload: false };
+  }
+  if (flags.allowDownload !== undefined)
+    return { offline: false, allowDownload: flags.allowDownload };
+  if (truthy(env.CODEGRAPH_NO_AUTO_DOWNLOAD)) return { offline: false, allowDownload: false };
+  return { offline: false, allowDownload: true };
+}
+
+function truthy(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true' || value?.toLowerCase() === 'yes';
+}
+
+export function isGgufModelUri(uri: string): boolean {
+  return uri.startsWith('hf:') || uri.startsWith('file:') || path.isAbsolute(uri);
+}
+
+export function parseModelUri(uri: string): ParsedModelUri {
+  if (uri.startsWith('hf:')) {
+    const rest = uri.slice(3);
+    const quantMatch = rest.match(HF_QUANT_PATTERN);
+    if (quantMatch) {
+      const [, org, repo, quantization] = quantMatch;
+      return { scheme: 'hf', org: org!, repo: repo!, file: '', quantization };
+    }
+    const pathMatch = rest.match(HF_PATH_PATTERN);
+    if (pathMatch) {
+      const [, org, repo, file] = pathMatch;
+      return { scheme: 'hf', org: org!, repo: repo!, file: file! };
+    }
+    throw new EngineError(
+      `Invalid model URI "${uri}". Expected hf:org/repo/model.gguf or hf:org/repo:QUANT.`,
+    );
+  }
+  if (uri.startsWith('file://')) {
+    try {
+      return { scheme: 'file', file: fileURLToPath(new URL(uri)) };
+    } catch (cause) {
+      throw new EngineError(`Invalid file model URI "${uri}".`, { cause: asError(cause) });
+    }
+  }
+  if (uri.startsWith('file:')) {
+    const file = uri.slice(5);
+    if (!file) throw new EngineError('Invalid file model URI: empty file path.');
+    return { scheme: 'file', file };
+  }
+  if (path.isAbsolute(uri)) return { scheme: 'file', file: uri };
+  throw new EngineError(
+    `Unsupported model URI "${uri}". Use a configured transformer model, http(s) endpoint, hf: URI, or file: URI.`,
+  );
+}
+
+export async function validateGgufFile(filePath: string, uri = filePath): Promise<void> {
+  let bytes: Buffer;
+  try {
+    const handle = await import('node:fs/promises').then((fs) => fs.open(filePath, 'r'));
+    try {
+      bytes = Buffer.alloc(512);
+      const result = await handle.read(bytes, 0, 512, 0);
+      bytes = bytes.subarray(0, result.bytesRead);
+    } finally {
+      await handle.close();
+    }
+  } catch (cause) {
+    throw new EngineError(`Model file not found for ${uri}: ${filePath}`, {
+      cause: asError(cause),
+    });
+  }
+
+  if (GGUF_MAGIC.every((value, index) => bytes[index] === value)) return;
+  const text = bytes.toString('utf8').toLowerCase();
+  if (text.includes('<!doctype') || text.includes('<html') || text.includes('huggingface')) {
+    throw new EngineError(
+      `Model file for ${uri} looks like HTML instead of GGUF: ${filePath}. A proxy, firewall, login page, or captive portal may have intercepted the download. Remove the file and retry with network access.`,
+    );
+  }
+  throw new EngineError(
+    `Model file for ${uri} is not a valid GGUF file: ${filePath} (missing GGUF magic header). Remove it and download the .gguf model again.`,
+  );
+}
+
+export class ModelCache {
+  readonly dir: string;
+  private readonly manifestPath: string;
+
+  constructor(cacheDir = path.join(os.homedir(), '.codegraph', 'models')) {
+    this.dir = cacheDir;
+    this.manifestPath = path.join(cacheDir, 'manifest.json');
+  }
+
+  async ensureModel(
+    uri: string,
+    type: ModelType,
+    policy = resolveDownloadPolicy(),
+  ): Promise<string> {
+    const parsed = parseModelUri(uri);
+    if (parsed.scheme === 'file') {
+      await validateGgufFile(parsed.file, uri);
+      return parsed.file;
+    }
+
+    const cached = await this.getCachedPath(uri);
+    if (cached) return cached;
+    if (policy.offline) {
+      throw new EngineError(
+        `Model ${uri} is not cached and offline mode is enabled. Disable CODEGRAPH_OFFLINE/HF_HUB_OFFLINE or pre-download the model into ${this.dir}.`,
+      );
+    }
+    if (!policy.allowDownload) {
+      throw new EngineError(
+        `Model ${uri} is not cached and automatic downloads are disabled. Set CODEGRAPH_NO_AUTO_DOWNLOAD=0 or pre-download the model into ${this.dir}.`,
+      );
+    }
+
+    let runtime: {
+      resolveModelFile?: (uri: string, options: { directory: string }) => Promise<string>;
+    };
+    try {
+      runtime = (await importOptionalRuntime('node-llama-cpp')) as typeof runtime;
+    } catch (cause) {
+      throw new EngineError(
+        'Qwen/GGUF embeddings require optional runtime node-llama-cpp. Install it only if you use GGUF models: npm install node-llama-cpp',
+        { cause: asError(cause) },
+      );
+    }
+    if (!runtime.resolveModelFile) {
+      throw new EngineError(
+        'node-llama-cpp does not expose resolveModelFile; update the optional runtime.',
+      );
+    }
+    await mkdir(this.dir, { recursive: true });
+    const resolvedPath = await runtime.resolveModelFile(toNodeLlamaCppUri(parsed), {
+      directory: this.dir,
+    });
+    await validateGgufFile(resolvedPath, uri);
+    await this.addToManifest(uri, type, resolvedPath);
+    return resolvedPath;
+  }
+
+  async getCachedPath(uri: string): Promise<string | null> {
+    const manifest = await this.loadManifest();
+    const entry = manifest.models.find((item) => item.uri === uri);
+    if (!entry) return null;
+    try {
+      await stat(entry.path);
+      await validateGgufFile(entry.path, uri);
+      return entry.path;
+    } catch {
+      await this.removeFromManifest(uri);
+      return null;
+    }
+  }
+
+  private async loadManifest(): Promise<Manifest> {
+    try {
+      return JSON.parse(await readFile(this.manifestPath, 'utf8')) as Manifest;
+    } catch {
+      return { version: '1.0', models: [] };
+    }
+  }
+
+  private async writeManifest(manifest: Manifest): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+    await writeFile(this.manifestPath, JSON.stringify(manifest, null, 2));
+  }
+
+  private async addToManifest(uri: string, type: ModelType, modelPath: string): Promise<void> {
+    const manifest = await this.loadManifest();
+    manifest.models = manifest.models.filter((item) => item.uri !== uri);
+    manifest.models.push({ uri, type, path: modelPath, cachedAt: new Date().toISOString() });
+    await this.writeManifest(manifest);
+  }
+
+  private async removeFromManifest(uri: string): Promise<void> {
+    const manifest = await this.loadManifest();
+    manifest.models = manifest.models.filter((item) => item.uri !== uri);
+    await this.writeManifest(manifest);
+  }
+}
+
+export async function clearCachedModelFile(filePath: string): Promise<void> {
+  await rm(filePath, { force: true });
+}
+
+function toNodeLlamaCppUri(parsed: ParsedModelUri): string {
+  if (parsed.scheme === 'file') return parsed.file;
+  return parsed.quantization
+    ? `hf:${parsed.org}/${parsed.repo}:${parsed.quantization}`
+    : `hf:${parsed.org}/${parsed.repo}/${parsed.file}`;
+}
+
+export function cacheKeyForUri(uri: string): string {
+  return createHash('sha256').update(uri).digest('hex').slice(0, 32);
+}

--- a/src/domain/search/model-cache.ts
+++ b/src/domain/search/model-cache.ts
@@ -41,6 +41,10 @@ function asError(cause: unknown): Error | undefined {
       : new Error(String(cause));
 }
 
+function isMissingFileError(cause: unknown): boolean {
+  return cause instanceof Error && (cause as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
 async function importOptionalRuntime(specifier: string): Promise<unknown> {
   return (
     new Function('specifier', 'return import(specifier)') as (value: string) => Promise<unknown>
@@ -201,12 +205,15 @@ export class ModelCache {
     if (!entry) return null;
     try {
       await stat(entry.path);
-      await validateGgufFile(entry.path, uri);
-      return entry.path;
-    } catch {
-      await this.removeFromManifest(uri);
-      return null;
+    } catch (cause) {
+      if (isMissingFileError(cause)) {
+        await this.removeFromManifest(uri);
+        return null;
+      }
+      throw cause;
     }
+    await validateGgufFile(entry.path, uri);
+    return entry.path;
   }
 
   private async findLocalCachedPath(parsed: ParsedModelUri, uri: string): Promise<string | null> {
@@ -218,11 +225,14 @@ export class ModelCache {
     ];
     for (const candidate of candidates) {
       try {
-        await validateGgufFile(candidate, uri);
-        return candidate;
-      } catch {
-        // Continue looking for deterministic local cache layouts before reporting a miss.
+        await stat(candidate);
+      } catch (cause) {
+        // Missing deterministic layouts are cache misses; existing invalid files are not.
+        if (isMissingFileError(cause)) continue;
+        throw cause;
       }
+      await validateGgufFile(candidate, uri);
+      return candidate;
     }
     return null;
   }

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -360,6 +360,7 @@ async function loadModel(modelKey?: string): Promise<{ extractor: unknown; confi
 }
 
 class TransformerEmbeddingPort implements EmbeddingPort {
+  private readonly modelKey: string;
   private loaded:
     | {
         ext: unknown;
@@ -367,7 +368,9 @@ class TransformerEmbeddingPort implements EmbeddingPort {
       }
     | undefined;
 
-  constructor(private readonly modelKey: string = LEGACY_TRANSFORMER_DEFAULT_MODEL) {}
+  constructor(modelKey: string = LEGACY_TRANSFORMER_DEFAULT_MODEL) {
+    this.modelKey = modelKey;
+  }
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
     if (!this.loaded) {
@@ -404,9 +407,13 @@ export function createTransformerEmbeddingPort(modelKey?: string): EmbeddingPort
   return new TransformerEmbeddingPort(modelKey ?? LEGACY_TRANSFORMER_DEFAULT_MODEL);
 }
 
-async function createDefaultEmbeddingPort(): Promise<EmbeddingPort> {
+async function createFactoryEmbeddingPort(modelUri: string): Promise<EmbeddingPort> {
   const { createEmbeddingPort } = await import('./embedding-factory.js');
-  return createEmbeddingPort(DEFAULT_MODEL, { inputType: 'raw' });
+  return createEmbeddingPort(modelUri, { inputType: 'raw' });
+}
+
+function isTransformerModelKeyOrName(modelKeyOrUri: string): boolean {
+  return MODELS[resolveModelKey(modelKeyOrUri)] != null;
 }
 
 /**
@@ -416,11 +423,12 @@ export async function embed(
   texts: string[],
   modelKey?: string,
 ): Promise<{ vectors: Float32Array[]; dim: number }> {
-  const config = modelKey ? getModelConfig(modelKey) : getEmbeddingModelConfig(DEFAULT_MODEL);
-  const batchSize = getEmbeddingBatchSize(modelKey);
-  const basePort = modelKey
-    ? createTransformerEmbeddingPort(modelKey)
-    : await createDefaultEmbeddingPort();
+  const modelKeyOrUri = modelKey ?? DEFAULT_MODEL;
+  const config = getEmbeddingModelConfig(modelKeyOrUri);
+  const batchSize = getEmbeddingBatchSize(modelKeyOrUri);
+  const basePort = isTransformerModelKeyOrName(modelKeyOrUri)
+    ? createTransformerEmbeddingPort(modelKeyOrUri)
+    : await createFactoryEmbeddingPort(modelKeyOrUri);
   let embeddedCount = 0;
   const progressPort: EmbeddingPort = {
     async embedBatch(batch) {

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -165,6 +165,19 @@ export function getModelConfig(modelKey?: string): ModelConfig {
   return config;
 }
 
+export function getEmbeddingModelConfig(modelKey?: string): ModelConfig {
+  const key = resolveModelKey(modelKey);
+  const config = MODELS[key];
+  if (config) return config;
+  return {
+    name: key,
+    dim: 0,
+    contextWindow: 8192,
+    desc: 'External embedding model',
+    quantized: false,
+  };
+}
+
 function resolveLegacyEmbeddingUri(config?: CodegraphConfig): string | undefined {
   const legacyModel = config?.embeddings?.model;
   if (!legacyModel) return undefined;

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -178,7 +178,9 @@ export function resolveRetrievalModels(config?: CodegraphConfig): ResolvedRetrie
   const roles: ModelRoleMap = { ...preset.roles };
   const overrides = config?.models?.roles;
 
-  const legacyEmbed = resolveLegacyEmbeddingUri(config);
+  const selectedNonDefaultPreset =
+    requestedPreset !== DEFAULT_RETRIEVAL_PRESET && preset.name === requestedPreset;
+  const legacyEmbed = selectedNonDefaultPreset ? undefined : resolveLegacyEmbeddingUri(config);
   const hasEmbedOverride = overrides?.embed != null;
   if (legacyEmbed && !hasEmbedOverride) {
     roles.embed = legacyEmbed;

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -2,6 +2,10 @@ import { execFileSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { info } from '../../infrastructure/logger.js';
 import { ConfigError, EngineError } from '../../shared/errors.js';
+import type { CodegraphConfig } from '../../types.js';
+
+export type ModelRole = 'embed' | 'rerank' | 'expand' | 'gen';
+export type ModelRoleMap = Record<ModelRole, string>;
 
 export interface ModelConfig {
   name: string;
@@ -74,6 +78,62 @@ export const MODELS: Record<string, ModelConfig> = {
 export const EMBEDDING_STRATEGIES: readonly string[] = ['structured', 'source'];
 
 export const DEFAULT_MODEL: string = 'nomic-v1.5';
+export const DEFAULT_RETRIEVAL_PRESET = 'codegraph-default';
+
+export interface RetrievalModelPreset {
+  name: string;
+  desc: string;
+  roles: ModelRoleMap;
+}
+
+export interface ResolvedRetrievalModels {
+  preset: string;
+  requestedPreset?: string;
+  roles: ModelRoleMap;
+}
+
+export const RETRIEVAL_MODEL_PRESETS: Record<string, RetrievalModelPreset> = {
+  [DEFAULT_RETRIEVAL_PRESET]: {
+    name: DEFAULT_RETRIEVAL_PRESET,
+    desc: 'Compatibility default: current Codegraph embedding model plus GNO-inspired retrieval roles.',
+    roles: {
+      embed: MODELS[DEFAULT_MODEL]!.name,
+      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
+      expand: 'hf:Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+      gen: 'hf:Qwen/Qwen2.5-1.5B-Instruct-GGUF',
+    },
+  },
+  'gno-compact': {
+    name: 'gno-compact',
+    desc: 'Compact GNO-inspired local retrieval model roles.',
+    roles: {
+      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
+      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
+      expand: 'hf:Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+      gen: 'hf:Qwen/Qwen2.5-1.5B-Instruct-GGUF',
+    },
+  },
+  'gno-balanced': {
+    name: 'gno-balanced',
+    desc: 'Balanced GNO-inspired retrieval model roles.',
+    roles: {
+      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
+      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
+      expand: 'hf:Qwen/Qwen2.5-1.5B-Instruct-GGUF',
+      gen: 'hf:Qwen/Qwen2.5-3B-Instruct-GGUF',
+    },
+  },
+  'gno-quality': {
+    name: 'gno-quality',
+    desc: 'Quality-oriented GNO-inspired retrieval model roles.',
+    roles: {
+      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
+      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
+      expand: 'hf:Qwen/Qwen2.5-3B-Instruct-GGUF',
+      gen: 'hf:Qwen/Qwen2.5-7B-Instruct-GGUF',
+    },
+  },
+};
 const NPM_BIN = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const BATCH_SIZE_MAP: Record<string, number> = {
   minilm: 32,
@@ -86,14 +146,60 @@ const BATCH_SIZE_MAP: Record<string, number> = {
 };
 const DEFAULT_BATCH_SIZE = 32;
 
+export function resolveModelKey(modelKeyOrUri?: string): string {
+  const requested = modelKeyOrUri || DEFAULT_MODEL;
+  if (MODELS[requested]) return requested;
+  const entry = Object.entries(MODELS).find(([, config]) => config.name === requested);
+  if (entry) return entry[0];
+  return requested;
+}
+
 /** @internal Used by generator.js — not part of the public barrel. */
 export function getModelConfig(modelKey?: string): ModelConfig {
-  const key = modelKey || DEFAULT_MODEL;
+  const key = resolveModelKey(modelKey);
   const config = MODELS[key];
   if (!config) {
     throw new ConfigError(`Unknown model: ${key}. Available: ${Object.keys(MODELS).join(', ')}`);
   }
   return config;
+}
+
+function resolveLegacyEmbeddingUri(config?: CodegraphConfig): string | undefined {
+  const legacyModel = config?.embeddings?.model;
+  if (!legacyModel) return undefined;
+  const key = resolveModelKey(legacyModel);
+  return MODELS[key]?.name ?? legacyModel;
+}
+
+export function resolveRetrievalModels(config?: CodegraphConfig): ResolvedRetrievalModels {
+  const requestedPreset = config?.models?.preset || DEFAULT_RETRIEVAL_PRESET;
+  const preset =
+    RETRIEVAL_MODEL_PRESETS[requestedPreset] ?? RETRIEVAL_MODEL_PRESETS[DEFAULT_RETRIEVAL_PRESET]!;
+  const roles: ModelRoleMap = { ...preset.roles };
+  const overrides = config?.models?.roles;
+
+  const legacyEmbed = resolveLegacyEmbeddingUri(config);
+  const hasEmbedOverride = overrides?.embed != null;
+  if (legacyEmbed && !hasEmbedOverride) {
+    roles.embed = legacyEmbed;
+  }
+
+  if (overrides) {
+    for (const role of ['embed', 'rerank', 'expand', 'gen'] as const) {
+      const uri = overrides[role];
+      if (uri) roles[role] = uri;
+    }
+  }
+
+  return {
+    preset: preset.name,
+    requestedPreset: requestedPreset === preset.name ? undefined : requestedPreset,
+    roles,
+  };
+}
+
+export function resolveModelRoleUri(config: CodegraphConfig | undefined, role: ModelRole): string {
+  return resolveRetrievalModels(config).roles[role];
 }
 
 /**
@@ -233,7 +339,8 @@ export async function embed(
   const { extractor: ext, config } = await loadModel(modelKey);
   const dim = config.dim;
   const results: Float32Array[] = [];
-  const batchSize = BATCH_SIZE_MAP[modelKey || DEFAULT_MODEL] ?? DEFAULT_BATCH_SIZE;
+  const batchModelKey = resolveModelKey(modelKey);
+  const batchSize = BATCH_SIZE_MAP[batchModelKey] ?? DEFAULT_BATCH_SIZE;
 
   for (let i = 0; i < texts.length; i += batchSize) {
     const batch = texts.slice(i, i + batchSize);

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -367,7 +367,7 @@ class TransformerEmbeddingPort implements EmbeddingPort {
       }
     | undefined;
 
-  constructor(private readonly modelKey?: string) {}
+  constructor(private readonly modelKey: string = LEGACY_TRANSFORMER_DEFAULT_MODEL) {}
 
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
     if (!this.loaded) {
@@ -401,7 +401,12 @@ class TransformerEmbeddingPort implements EmbeddingPort {
 }
 
 export function createTransformerEmbeddingPort(modelKey?: string): EmbeddingPort {
-  return new TransformerEmbeddingPort(modelKey);
+  return new TransformerEmbeddingPort(modelKey ?? LEGACY_TRANSFORMER_DEFAULT_MODEL);
+}
+
+async function createDefaultEmbeddingPort(): Promise<EmbeddingPort> {
+  const { createEmbeddingPort } = await import('./embedding-factory.js');
+  return createEmbeddingPort(DEFAULT_MODEL, { inputType: 'raw' });
 }
 
 /**
@@ -411,13 +416,15 @@ export async function embed(
   texts: string[],
   modelKey?: string,
 ): Promise<{ vectors: Float32Array[]; dim: number }> {
-  const config = getModelConfig(modelKey);
+  const config = modelKey ? getModelConfig(modelKey) : getEmbeddingModelConfig(DEFAULT_MODEL);
   const batchSize = getEmbeddingBatchSize(modelKey);
-  const transformerPort = createTransformerEmbeddingPort(modelKey);
+  const basePort = modelKey
+    ? createTransformerEmbeddingPort(modelKey)
+    : await createDefaultEmbeddingPort();
   let embeddedCount = 0;
   const progressPort: EmbeddingPort = {
     async embedBatch(batch) {
-      const vectors = await transformerPort.embedBatch(batch);
+      const vectors = await basePort.embedBatch(batch);
       embeddedCount += batch.length;
       if (texts.length > batchSize) {
         process.stderr.write(
@@ -426,8 +433,8 @@ export async function embed(
       }
       return vectors;
     },
-    reset: () => transformerPort.reset?.(),
+    reset: () => basePort.reset?.(),
   };
   const vectors = await embedWithRecovery(progressPort, texts, { batchSize });
-  return { vectors, dim: config.dim };
+  return { vectors, dim: config.dim || vectors[0]?.length || 0 };
 }

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -78,8 +78,13 @@ export const MODELS: Record<string, ModelConfig> = {
 
 export const EMBEDDING_STRATEGIES: readonly string[] = ['structured', 'source'];
 
-export const DEFAULT_MODEL: string = 'nomic-v1.5';
-export const DEFAULT_RETRIEVAL_PRESET = 'codegraph-default';
+export const GNO_COMPACT_EMBEDDING_MODEL =
+  'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf';
+export const DEFAULT_EMBEDDING_MODEL = GNO_COMPACT_EMBEDDING_MODEL;
+export const LEGACY_TRANSFORMER_DEFAULT_MODEL = 'nomic-v1.5';
+export const DEFAULT_MODEL: string = DEFAULT_EMBEDDING_MODEL;
+export const DEFAULT_RETRIEVAL_PRESET = 'gno-compact';
+export const LEGACY_RETRIEVAL_PRESET = 'codegraph-default';
 
 export interface RetrievalModelPreset {
   name: string;
@@ -94,21 +99,21 @@ export interface ResolvedRetrievalModels {
 }
 
 export const RETRIEVAL_MODEL_PRESETS: Record<string, RetrievalModelPreset> = {
-  [DEFAULT_RETRIEVAL_PRESET]: {
-    name: DEFAULT_RETRIEVAL_PRESET,
-    desc: 'Compatibility default: current Codegraph embedding model plus GNO-inspired retrieval roles.',
+  [LEGACY_RETRIEVAL_PRESET]: {
+    name: LEGACY_RETRIEVAL_PRESET,
+    desc: 'Legacy compatibility preset: previous Codegraph embedding model plus GNO-inspired retrieval roles.',
     roles: {
-      embed: MODELS[DEFAULT_MODEL]!.name,
+      embed: MODELS[LEGACY_TRANSFORMER_DEFAULT_MODEL]!.name,
       rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
       expand: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
       gen: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
     },
   },
-  'gno-compact': {
-    name: 'gno-compact',
+  [DEFAULT_RETRIEVAL_PRESET]: {
+    name: DEFAULT_RETRIEVAL_PRESET,
     desc: 'Compact GNO-inspired local retrieval model roles.',
     roles: {
-      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      embed: GNO_COMPACT_EMBEDDING_MODEL,
       rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
       expand: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
       gen: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
@@ -118,7 +123,7 @@ export const RETRIEVAL_MODEL_PRESETS: Record<string, RetrievalModelPreset> = {
     name: 'gno-balanced',
     desc: 'Balanced GNO-inspired retrieval model roles.',
     roles: {
-      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      embed: GNO_COMPACT_EMBEDDING_MODEL,
       rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
       expand: 'hf:bartowski/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf',
       gen: 'hf:bartowski/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf',
@@ -128,7 +133,7 @@ export const RETRIEVAL_MODEL_PRESETS: Record<string, RetrievalModelPreset> = {
     name: 'gno-quality',
     desc: 'Quality-oriented GNO-inspired retrieval model roles.',
     roles: {
-      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      embed: GNO_COMPACT_EMBEDDING_MODEL,
       rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
       expand: 'hf:unsloth/Qwen3-4B-Instruct-2507-GGUF/Qwen3-4B-Instruct-2507-Q4_K_M.gguf',
       gen: 'hf:unsloth/Qwen3-4B-Instruct-2507-GGUF/Qwen3-4B-Instruct-2507-Q4_K_M.gguf',
@@ -183,11 +188,11 @@ export function getEmbeddingModelConfig(modelKey?: string): ModelConfig {
   };
 }
 
-function resolveLegacyEmbeddingUri(config?: CodegraphConfig): string | undefined {
-  const legacyModel = config?.embeddings?.model;
-  if (!legacyModel) return undefined;
-  const key = resolveModelKey(legacyModel);
-  return MODELS[key]?.name ?? legacyModel;
+function resolveConfiguredEmbeddingUri(config?: CodegraphConfig): string | undefined {
+  const configuredModel = config?.embeddings?.model;
+  if (!configuredModel || configuredModel === DEFAULT_EMBEDDING_MODEL) return undefined;
+  const key = resolveModelKey(configuredModel);
+  return MODELS[key]?.name ?? configuredModel;
 }
 
 export function resolveRetrievalModels(config?: CodegraphConfig): ResolvedRetrievalModels {
@@ -197,12 +202,16 @@ export function resolveRetrievalModels(config?: CodegraphConfig): ResolvedRetrie
   const roles: ModelRoleMap = { ...preset.roles };
   const overrides = config?.models?.roles;
 
-  const selectedNonDefaultPreset =
-    requestedPreset !== DEFAULT_RETRIEVAL_PRESET && preset.name === requestedPreset;
-  const legacyEmbed = selectedNonDefaultPreset ? undefined : resolveLegacyEmbeddingUri(config);
+  const selectedBuiltInPresetWithOwnEmbedding =
+    requestedPreset !== DEFAULT_RETRIEVAL_PRESET &&
+    requestedPreset !== LEGACY_RETRIEVAL_PRESET &&
+    preset.name === requestedPreset;
+  const configuredEmbed = selectedBuiltInPresetWithOwnEmbedding
+    ? undefined
+    : resolveConfiguredEmbeddingUri(config);
   const hasEmbedOverride = overrides?.embed != null;
-  if (legacyEmbed && !hasEmbedOverride) {
-    roles.embed = legacyEmbed;
+  if (configuredEmbed && !hasEmbedOverride) {
+    roles.embed = configuredEmbed;
   }
 
   if (overrides) {

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -3,6 +3,7 @@ import { createInterface } from 'node:readline';
 import { info } from '../../infrastructure/logger.js';
 import { ConfigError, EngineError } from '../../shared/errors.js';
 import type { CodegraphConfig } from '../../types.js';
+import { type EmbeddingPort, embedWithRecovery } from './ports.js';
 
 export type ModelRole = 'embed' | 'rerank' | 'expand' | 'gen';
 export type ModelRoleMap = Record<ModelRole, string>;
@@ -331,6 +332,51 @@ async function loadModel(modelKey?: string): Promise<{ extractor: unknown; confi
   return { extractor, config };
 }
 
+class TransformerEmbeddingPort implements EmbeddingPort {
+  private loaded:
+    | {
+        ext: unknown;
+        config: ModelConfig;
+      }
+    | undefined;
+
+  constructor(private readonly modelKey?: string) {}
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    if (!this.loaded) {
+      const { extractor: ext, config } = await loadModel(this.modelKey);
+      this.loaded = { ext, config };
+    }
+
+    const { ext, config } = this.loaded;
+    const output =
+      (await // biome-ignore lint/complexity/noBannedTypes: dynamically loaded extractor is untyped
+      (ext as Function)(texts, { pooling: 'mean', normalize: true })) as {
+        data: number[];
+      };
+
+    const vectors: Float32Array[] = [];
+    for (let j = 0; j < texts.length; j++) {
+      const start = j * config.dim;
+      const vec = new Float32Array(config.dim);
+      for (let k = 0; k < config.dim; k++) {
+        vec[k] = output.data[start + k] ?? 0;
+      }
+      vectors.push(vec);
+    }
+    return vectors;
+  }
+
+  async reset(): Promise<void> {
+    this.loaded = undefined;
+    await disposeModel();
+  }
+}
+
+export function createTransformerEmbeddingPort(modelKey?: string): EmbeddingPort {
+  return new TransformerEmbeddingPort(modelKey);
+}
+
 /**
  * Generate embeddings for an array of texts.
  */
@@ -338,33 +384,24 @@ export async function embed(
   texts: string[],
   modelKey?: string,
 ): Promise<{ vectors: Float32Array[]; dim: number }> {
-  const { extractor: ext, config } = await loadModel(modelKey);
-  const dim = config.dim;
-  const results: Float32Array[] = [];
+  const config = getModelConfig(modelKey);
   const batchModelKey = resolveModelKey(modelKey);
   const batchSize = BATCH_SIZE_MAP[batchModelKey] ?? DEFAULT_BATCH_SIZE;
-
-  for (let i = 0; i < texts.length; i += batchSize) {
-    const batch = texts.slice(i, i + batchSize);
-    const output =
-      (await // biome-ignore lint/complexity/noBannedTypes: dynamically loaded extractor is untyped
-      (ext as Function)(batch, { pooling: 'mean', normalize: true })) as {
-        data: number[];
-      };
-
-    for (let j = 0; j < batch.length; j++) {
-      const start = j * dim;
-      const vec = new Float32Array(dim);
-      for (let k = 0; k < dim; k++) {
-        vec[k] = output.data[start + k] ?? 0;
+  const transformerPort = createTransformerEmbeddingPort(modelKey);
+  let embeddedCount = 0;
+  const progressPort: EmbeddingPort = {
+    async embedBatch(batch) {
+      const vectors = await transformerPort.embedBatch(batch);
+      embeddedCount += batch.length;
+      if (texts.length > batchSize) {
+        process.stderr.write(
+          `  Embedded ${Math.min(embeddedCount, texts.length)}/${texts.length}\r`,
+        );
       }
-      results.push(vec);
-    }
-
-    if (texts.length > batchSize) {
-      process.stderr.write(`  Embedded ${Math.min(i + batchSize, texts.length)}/${texts.length}\r`);
-    }
-  }
-
-  return { vectors: results, dim };
+      return vectors;
+    },
+    reset: () => transformerPort.reset?.(),
+  };
+  const vectors = await embedWithRecovery(progressPort, texts, { batchSize });
+  return { vectors, dim: config.dim };
 }

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -99,39 +99,39 @@ export const RETRIEVAL_MODEL_PRESETS: Record<string, RetrievalModelPreset> = {
     desc: 'Compatibility default: current Codegraph embedding model plus GNO-inspired retrieval roles.',
     roles: {
       embed: MODELS[DEFAULT_MODEL]!.name,
-      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
-      expand: 'hf:Qwen/Qwen2.5-0.5B-Instruct-GGUF',
-      gen: 'hf:Qwen/Qwen2.5-1.5B-Instruct-GGUF',
+      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
+      expand: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
+      gen: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
     },
   },
   'gno-compact': {
     name: 'gno-compact',
     desc: 'Compact GNO-inspired local retrieval model roles.',
     roles: {
-      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
-      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
-      expand: 'hf:Qwen/Qwen2.5-0.5B-Instruct-GGUF',
-      gen: 'hf:Qwen/Qwen2.5-1.5B-Instruct-GGUF',
+      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
+      expand: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
+      gen: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
     },
   },
   'gno-balanced': {
     name: 'gno-balanced',
     desc: 'Balanced GNO-inspired retrieval model roles.',
     roles: {
-      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
-      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
-      expand: 'hf:Qwen/Qwen2.5-1.5B-Instruct-GGUF',
-      gen: 'hf:Qwen/Qwen2.5-3B-Instruct-GGUF',
+      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
+      expand: 'hf:bartowski/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf',
+      gen: 'hf:bartowski/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf',
     },
   },
   'gno-quality': {
     name: 'gno-quality',
     desc: 'Quality-oriented GNO-inspired retrieval model roles.',
     roles: {
-      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
-      rerank: 'hf:Qwen/Qwen3-Reranker-0.6B-GGUF',
-      expand: 'hf:Qwen/Qwen2.5-3B-Instruct-GGUF',
-      gen: 'hf:Qwen/Qwen2.5-7B-Instruct-GGUF',
+      embed: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
+      expand: 'hf:unsloth/Qwen3-4B-Instruct-2507-GGUF/Qwen3-4B-Instruct-2507-Q4_K_M.gguf',
+      gen: 'hf:unsloth/Qwen3-4B-Instruct-2507-GGUF/Qwen3-4B-Instruct-2507-Q4_K_M.gguf',
     },
   },
 };
@@ -146,6 +146,11 @@ const BATCH_SIZE_MAP: Record<string, number> = {
   'bge-large': 4,
 };
 const DEFAULT_BATCH_SIZE = 32;
+
+export function getEmbeddingBatchSize(modelKeyOrUri?: string): number {
+  const batchModelKey = resolveModelKey(modelKeyOrUri);
+  return BATCH_SIZE_MAP[batchModelKey] ?? DEFAULT_BATCH_SIZE;
+}
 
 export function resolveModelKey(modelKeyOrUri?: string): string {
   const requested = modelKeyOrUri || DEFAULT_MODEL;
@@ -398,8 +403,7 @@ export async function embed(
   modelKey?: string,
 ): Promise<{ vectors: Float32Array[]; dim: number }> {
   const config = getModelConfig(modelKey);
-  const batchModelKey = resolveModelKey(modelKey);
-  const batchSize = BATCH_SIZE_MAP[batchModelKey] ?? DEFAULT_BATCH_SIZE;
+  const batchSize = getEmbeddingBatchSize(modelKey);
   const transformerPort = createTransformerEmbeddingPort(modelKey);
   let embeddedCount = 0;
   const progressPort: EmbeddingPort = {

--- a/src/domain/search/ports.ts
+++ b/src/domain/search/ports.ts
@@ -1,0 +1,91 @@
+export interface EmbeddingPort {
+  embedBatch(texts: string[]): Promise<Float32Array[]>;
+  reset?(): Promise<void> | void;
+}
+
+export interface EmbeddingRecoveryOptions {
+  batchSize?: number;
+  sampleErrors?: number;
+}
+
+interface ItemFailure {
+  index: number;
+  text: string;
+  error: unknown;
+}
+
+const DEFAULT_BATCH_SIZE = 32;
+const DEFAULT_SAMPLE_ERRORS = 3;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function resetPort(port: EmbeddingPort): Promise<void> {
+  if (port.reset) await port.reset();
+}
+
+async function embedRange(
+  port: EmbeddingPort,
+  texts: string[],
+  offset: number,
+  failures: ItemFailure[],
+): Promise<Array<Float32Array | undefined>> {
+  try {
+    const vectors = await port.embedBatch(texts);
+    if (vectors.length !== texts.length) {
+      throw new Error(
+        `Embedding port returned ${vectors.length} vector(s) for ${texts.length} text(s)`,
+      );
+    }
+    return vectors;
+  } catch (error) {
+    if (texts.length === 1) {
+      failures.push({ index: offset, text: texts[0] ?? '', error });
+      return [undefined];
+    }
+
+    await resetPort(port);
+    const midpoint = Math.ceil(texts.length / 2);
+    const left = await embedRange(port, texts.slice(0, midpoint), offset, failures);
+    const right = await embedRange(port, texts.slice(midpoint), offset + midpoint, failures);
+    return [...left, ...right];
+  }
+}
+
+function failureSummary(failures: ItemFailure[], sampleErrors: number): string {
+  return failures
+    .slice(0, sampleErrors)
+    .map((failure) => {
+      const preview = failure.text.replace(/\s+/g, ' ').slice(0, 80);
+      return `#${failure.index}: ${errorMessage(failure.error)}${preview ? ` (${preview})` : ''}`;
+    })
+    .join('; ');
+}
+
+export async function embedWithRecovery(
+  port: EmbeddingPort,
+  texts: string[],
+  options: EmbeddingRecoveryOptions = {},
+): Promise<Float32Array[]> {
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const sampleErrors = options.sampleErrors ?? DEFAULT_SAMPLE_ERRORS;
+  const vectors: Array<Float32Array | undefined> = [];
+  const failures: ItemFailure[] = [];
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    vectors.push(...(await embedRange(port, batch, i, failures)));
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to embed ${failures.length} of ${texts.length} item(s). Sample errors: ${failureSummary(
+        failures,
+        sampleErrors,
+      )}`,
+    );
+  }
+
+  return vectors as Float32Array[];
+}

--- a/src/domain/search/ports.ts
+++ b/src/domain/search/ports.ts
@@ -1,3 +1,5 @@
+import { CodegraphError } from '../../shared/errors.js';
+
 export interface EmbeddingPort {
   embedBatch(texts: string[]): Promise<Float32Array[]>;
   reset?(): Promise<void> | void;
@@ -40,6 +42,10 @@ async function embedRange(
     }
     return vectors;
   } catch (error) {
+    if (error instanceof CodegraphError) {
+      throw error;
+    }
+
     if (texts.length === 1) {
       failures.push({ index: offset, text: texts[0] ?? '', error });
       return [undefined];

--- a/src/domain/search/search/cli-formatter.ts
+++ b/src/domain/search/search/cli-formatter.ts
@@ -130,6 +130,15 @@ function formatHybridResults(
       if (parts.length > 0) {
         console.log(`    ${parts.join('  |  ')}`);
       }
+      if (opts.explain && r.explain?.sources?.length) {
+        const sources = r.explain.sources
+          .map(
+            (source: { source: string; stage: string; rank: number; weight: number }) =>
+              `${source.stage}/${source.source}: rank ${source.rank}, weight ${source.weight}`,
+          )
+          .join('  |  ');
+        console.log(`    Explain: ${sources}`);
+      }
     }
   }
 

--- a/src/domain/search/search/expansion.ts
+++ b/src/domain/search/search/expansion.ts
@@ -1,0 +1,307 @@
+const JSON_EXTRACT_PATTERN = /\{[\s\S]*?\}/;
+const QUOTED_PHRASE_PATTERN = /"([^"]+)"/g;
+const NEGATION_PATTERN = /-(?:"([^"]+)"|([^\s]+))/g;
+const TOKEN_PATTERN = /[A-Za-z0-9][A-Za-z0-9.+#_-]*/g;
+const MAX_VARIANTS = 5;
+const DEFAULT_TIMEOUT_MS = 5000;
+const STRONG_BM25_MIN_SCORE = 0.84;
+const STRONG_BM25_MIN_GAP = 0.14;
+const STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'how',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'what',
+  'when',
+  'where',
+  'which',
+  'who',
+  'why',
+  'with',
+]);
+
+export interface ExpansionResult {
+  lexicalQueries: string[];
+  vectorQueries: string[];
+  hyde?: string;
+  notes?: string;
+}
+
+export interface ExpansionProvider {
+  generate(
+    prompt: string,
+    options: { temperature: 0; seed: 42; maxTokens: number },
+  ): Promise<string>;
+}
+
+export interface QueryExpansionOptions {
+  enabled?: boolean;
+  provider?: ExpansionProvider;
+  timeoutMs?: number;
+}
+
+export interface RoutedQueries {
+  bm25Queries: string[];
+  semanticQueries: string[];
+  expansion: ExpansionResult | null;
+  skipped: 'disabled' | 'no_provider' | 'strong_bm25' | 'failed' | null;
+}
+
+interface QuerySignals {
+  quotedPhrases: string[];
+  negations: string[];
+  criticalEntities: string[];
+  overlapTokens: Set<string>;
+}
+
+export interface Bm25SignalResult {
+  name?: string;
+  bm25Score: number;
+}
+
+function dedupeStrings(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function extractOverlapTokens(text: string): Set<string> {
+  const tokens = text.match(TOKEN_PATTERN) ?? [];
+  return new Set(
+    tokens
+      .map((token) => token.toLowerCase().trim())
+      .filter((token) => token.length >= 2 && !STOPWORDS.has(token)),
+  );
+}
+
+function extractQuerySignals(query: string): QuerySignals {
+  const quotedPhrases = dedupeStrings(
+    [...query.matchAll(QUOTED_PHRASE_PATTERN)].map((match) => match[1]?.trim() ?? ''),
+  );
+  const negations = dedupeStrings(
+    [...query.matchAll(NEGATION_PATTERN)].map((match) => {
+      const phrase = match[1]?.trim();
+      if (phrase) return `-"${phrase}"`;
+      const token = match[2]?.trim();
+      return token ? `-${token}` : '';
+    }),
+  );
+  const criticalEntities = dedupeStrings(
+    (query.match(TOKEN_PATTERN) ?? []).filter(
+      (token) => /[A-Z]/.test(token) || /[+#.]/.test(token) || /[A-Za-z]\d|\d[A-Za-z]/.test(token),
+    ),
+  );
+  return { quotedPhrases, negations, criticalEntities, overlapTokens: extractOverlapTokens(query) };
+}
+
+function hasCaseInsensitiveSubstring(text: string, part: string): boolean {
+  return text.toLowerCase().includes(part.toLowerCase());
+}
+
+function hasSufficientOverlap(signals: QuerySignals, candidate: string): boolean {
+  if (!candidate.trim()) return false;
+  for (const phrase of signals.quotedPhrases)
+    if (hasCaseInsensitiveSubstring(candidate, phrase)) return true;
+  for (const negation of signals.negations)
+    if (hasCaseInsensitiveSubstring(candidate, negation)) return true;
+  for (const entity of signals.criticalEntities)
+    if (hasCaseInsensitiveSubstring(candidate, entity)) return true;
+  for (const token of extractOverlapTokens(candidate))
+    if (signals.overlapTokens.has(token)) return true;
+  return false;
+}
+
+function buildAnchorLexicalQuery(query: string, signals: QuerySignals): string {
+  const parts = [
+    ...signals.criticalEntities,
+    ...signals.quotedPhrases.map((phrase) => `"${phrase}"`),
+    ...signals.negations,
+  ];
+  return dedupeStrings(parts).join(' ').trim() || query.trim();
+}
+
+export function applyExpansionGuardrails(
+  query: string,
+  expansion: ExpansionResult,
+): ExpansionResult {
+  const signals = extractQuerySignals(query);
+  const lexical = dedupeStrings([
+    buildAnchorLexicalQuery(query, signals),
+    ...expansion.lexicalQueries,
+  ])
+    .filter((variant) => hasSufficientOverlap(signals, variant))
+    .slice(0, MAX_VARIANTS);
+  const vector = dedupeStrings(expansion.vectorQueries)
+    .filter((variant) => hasSufficientOverlap(signals, variant))
+    .slice(0, MAX_VARIANTS);
+  const hyde =
+    expansion.hyde && hasSufficientOverlap(signals, expansion.hyde)
+      ? expansion.hyde.trim()
+      : undefined;
+
+  return {
+    lexicalQueries: lexical.length > 0 ? lexical : [query.trim()],
+    vectorQueries: vector.length > 0 ? vector : [query.trim()],
+    ...(hyde ? { hyde } : {}),
+    ...(expansion.notes ? { notes: expansion.notes } : {}),
+  };
+}
+
+export function parseExpansionOutput(output: string, query: string): ExpansionResult | null {
+  try {
+    const match = output.match(JSON_EXTRACT_PATTERN);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]) as Record<string, unknown>;
+    if (!Array.isArray(parsed.lexicalQueries) || !Array.isArray(parsed.vectorQueries)) return null;
+    const expansion: ExpansionResult = {
+      lexicalQueries: parsed.lexicalQueries
+        .filter((q): q is string => typeof q === 'string' && q.trim().length > 0)
+        .slice(0, MAX_VARIANTS),
+      vectorQueries: parsed.vectorQueries
+        .filter((q): q is string => typeof q === 'string' && q.trim().length > 0)
+        .slice(0, MAX_VARIANTS),
+    };
+    if (typeof parsed.hyde === 'string' && parsed.hyde.trim()) expansion.hyde = parsed.hyde.trim();
+    if (typeof parsed.notes === 'string') expansion.notes = parsed.notes;
+    return applyExpansionGuardrails(query, expansion);
+  } catch {
+    return null;
+  }
+}
+
+export function buildExpansionPrompt(query: string): string {
+  return `You expand search queries for Codegraph hybrid code search.\n\nQuery: "${query}"\n\nGenerate JSON with:\n1. "lexicalQueries": 2-3 keyword variations for BM25\n2. "vectorQueries": 2-3 semantic rephrasings for embeddings\n3. "hyde": one 50-100 word passage that directly answers the query as if from code documentation\n\nRules:\n- Keep identifiers, proper nouns, acronyms, quoted phrases, negations, and code symbols exactly as written\n- Lexical queries must preserve quoted phrases and negated terms\n- Keep symbol-heavy technical entities exactly, for example C++, C#, Node.js, React.useEffect\n- Be concise; each variation should be 3-8 words\n- HyDE should read like documentation, not a question\n\nRespond with valid JSON only.`;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+export async function expandOrFallback(
+  query: string,
+  options: QueryExpansionOptions = {},
+): Promise<ExpansionResult | null> {
+  if (!options.enabled || !options.provider) return null;
+  try {
+    const output = await withTimeout(
+      options.provider.generate(buildExpansionPrompt(query), {
+        temperature: 0,
+        seed: 42,
+        maxTokens: 512,
+      }),
+      options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    return output ? parseExpansionOutput(output, query) : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeExactQuery(query: string): string {
+  return query
+    .trim()
+    .replace(/^"(.*)"$/, '$1')
+    .toLowerCase();
+}
+
+export function hasStrongBm25Signal(results: Bm25SignalResult[]): boolean {
+  const [top, second] = results;
+  if (!top) return false;
+  const gap = top.bm25Score - (second?.bm25Score ?? 0);
+  return top.bm25Score >= STRONG_BM25_MIN_SCORE && gap >= STRONG_BM25_MIN_GAP;
+}
+
+export function hasStrongExactBm25Signal(query: string, results: Bm25SignalResult[]): boolean {
+  const [top, second] = results;
+  if (!top) return false;
+  const normalizedQuery = normalizeExactQuery(query);
+  const exactName = top.name?.toLowerCase() === normalizedQuery;
+  const gap = top.bm25Score - (second?.bm25Score ?? 0);
+  return hasStrongBm25Signal(results) || Boolean(exactName && top.bm25Score > 0 && gap > 0);
+}
+
+export async function routeExpandedQueries(
+  query: string,
+  options: QueryExpansionOptions,
+  bm25ProbeResults: Bm25SignalResult[],
+): Promise<RoutedQueries> {
+  const original = query.trim();
+  if (!options.enabled) {
+    return {
+      bm25Queries: [original],
+      semanticQueries: [original],
+      expansion: null,
+      skipped: 'disabled',
+    };
+  }
+  if (hasStrongExactBm25Signal(original, bm25ProbeResults)) {
+    return {
+      bm25Queries: [original],
+      semanticQueries: [original],
+      expansion: null,
+      skipped: 'strong_bm25',
+    };
+  }
+  if (!options.provider) {
+    return {
+      bm25Queries: [original],
+      semanticQueries: [original],
+      expansion: null,
+      skipped: 'no_provider',
+    };
+  }
+  const expansion = await expandOrFallback(original, options);
+  if (!expansion) {
+    return {
+      bm25Queries: [original],
+      semanticQueries: [original],
+      expansion: null,
+      skipped: 'failed',
+    };
+  }
+  return {
+    bm25Queries: dedupeStrings([original, ...expansion.lexicalQueries]),
+    semanticQueries: dedupeStrings([
+      original,
+      ...expansion.vectorQueries,
+      ...(expansion.hyde ? [expansion.hyde] : []),
+    ]),
+    expansion,
+    skipped: null,
+  };
+}

--- a/src/domain/search/search/expansion.ts
+++ b/src/domain/search/search/expansion.ts
@@ -36,6 +36,20 @@ const STOPWORDS = new Set([
   'with',
 ]);
 
+export type QueryMode = 'term' | 'intent' | 'hyde';
+
+export interface QueryModeInput {
+  mode: QueryMode;
+  text: string;
+}
+
+export interface StructuredQueryNormalization {
+  query: string;
+  queryModes: QueryModeInput[];
+  usedStructuredQuerySyntax: boolean;
+  derivedQuery: boolean;
+}
+
 export interface ExpansionResult {
   lexicalQueries: string[];
   vectorQueries: string[];
@@ -54,6 +68,7 @@ export interface QueryExpansionOptions {
   enabled?: boolean;
   provider?: ExpansionProvider;
   timeoutMs?: number;
+  queryModes?: QueryModeInput[];
 }
 
 export interface RoutedQueries {
@@ -208,6 +223,171 @@ function buildAnchorLexicalQuery(query: string, signals: QuerySignals): string {
   return dedupeStrings(parts).join(' ').trim() || query.trim();
 }
 
+const QUERY_MODE_ENTRY = /^\s*(term|intent|hyde)\s*:\s*([\s\S]*\S[\s\S]*)\s*$/i;
+const ANY_PREFIX_PATTERN = /^\s*([a-z][a-z0-9_-]*)\s*:\s*(.*)$/i;
+const RECOGNIZED_PREFIX_PATTERN = /^\s*(term|intent|hyde)\s*:\s*(.*)$/i;
+const RECOGNIZED_MODE_PREFIXES = new Set(['term', 'intent', 'hyde']);
+
+function structuredQueryError(message: string, line?: number | null): Error {
+  return new Error(line == null ? message : `Structured query line ${line}: ${message}`);
+}
+
+export function parseQueryModeSpec(spec: string): QueryModeInput {
+  const prefix = spec.match(/^\s*([a-z][a-z0-9_-]*)\s*:/i)?.[1]?.toLowerCase();
+  const match = spec.match(QUERY_MODE_ENTRY);
+  if (!match) {
+    if (prefix && RECOGNIZED_MODE_PREFIXES.has(prefix)) {
+      throw new Error(
+        `Invalid --query-mode value "${spec}". Expected non-empty text after ${prefix}:`,
+      );
+    }
+    throw new Error(
+      `Invalid --query-mode value "${spec}". Expected "term:<text>", "intent:<text>", or "hyde:<text>".`,
+    );
+  }
+  return { mode: match[1]!.toLowerCase() as QueryMode, text: match[2]!.trim() };
+}
+
+function normalizeQueryModeEntries(queryModes: QueryModeInput[]): QueryModeInput[] {
+  return queryModes.map((entry) => ({
+    mode: entry.mode,
+    text: entry.text.trim(),
+  }));
+}
+
+function validateQueryModeShape(queryModes: QueryModeInput[]): QueryModeInput[] {
+  const normalized = normalizeQueryModeEntries(queryModes);
+  for (const entry of normalized) {
+    if (!RECOGNIZED_MODE_PREFIXES.has(entry.mode) || !entry.text) {
+      throw new Error('Query modes must use term, intent, or hyde with non-empty text.');
+    }
+  }
+  if (normalized.filter((entry) => entry.mode === 'hyde').length > 1) {
+    throw new Error('Only one hyde mode is allowed in structured query input.');
+  }
+  return normalized;
+}
+
+export function validateQueryModes(queryModes: QueryModeInput[]): QueryModeInput[] {
+  const normalized = validateQueryModeShape(queryModes);
+  if (normalized.length > 0 && normalized.every((entry) => entry.mode === 'hyde')) {
+    throw new Error('HyDE-only inputs are not allowed; include a plain query, term, or intent.');
+  }
+  return normalized;
+}
+
+export function parseQueryModeSpecs(specs: string[]): QueryModeInput[] {
+  return validateQueryModeShape(specs.map((spec) => parseQueryModeSpec(spec)));
+}
+
+export function normalizeStructuredQueryInput(
+  query: string,
+  explicitQueryModes: QueryModeInput[] = [],
+): StructuredQueryNormalization {
+  const explicit = validateQueryModeShape(explicitQueryModes);
+  if (!query.includes('\n')) {
+    return { query, queryModes: explicit, usedStructuredQuerySyntax: false, derivedQuery: false };
+  }
+
+  const nonBlankLines = query.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (nonBlankLines.length === 0) {
+    return { query, queryModes: explicit, usedStructuredQuerySyntax: false, derivedQuery: false };
+  }
+
+  const hasTypedLine = nonBlankLines.some((line) => ANY_PREFIX_PATTERN.test(line.trim()));
+  if (!hasTypedLine) {
+    return { query, queryModes: explicit, usedStructuredQuerySyntax: false, derivedQuery: false };
+  }
+
+  const queryModes: QueryModeInput[] = [];
+  const bodyLines: string[] = [];
+  let hydeCount = 0;
+
+  for (const [index, line] of query.split(/\r?\n/).entries()) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const recognized = trimmed.match(RECOGNIZED_PREFIX_PATTERN);
+    if (recognized) {
+      const mode = recognized[1]!.toLowerCase() as QueryMode;
+      const text = recognized[2]?.trim() ?? '';
+      if (!text)
+        throw structuredQueryError(`line ${index + 1} must contain non-empty text after ${mode}:`);
+      if (mode === 'hyde') {
+        hydeCount += 1;
+        if (hydeCount > 1)
+          throw structuredQueryError(
+            'Only one hyde line is allowed in a structured query document.',
+            index + 1,
+          );
+      }
+      queryModes.push({ mode, text });
+      continue;
+    }
+
+    const prefixed = trimmed.match(ANY_PREFIX_PATTERN);
+    if (prefixed?.[1]) {
+      const prefix = prefixed[1].toLowerCase();
+      if (!RECOGNIZED_MODE_PREFIXES.has(prefix)) {
+        throw structuredQueryError(
+          `Unknown structured query line prefix "${prefix}:" on line ${index + 1}. Expected term:, intent:, or hyde:.`,
+          index + 1,
+        );
+      }
+    }
+    bodyLines.push(trimmed);
+  }
+
+  const combinedQueryModes = normalizeQueryModeEntries([...queryModes, ...explicit]);
+  if (combinedQueryModes.filter((entry) => entry.mode === 'hyde').length > 1) {
+    throw new Error(
+      'Only one hyde entry is allowed across structured query syntax and explicit query modes.',
+    );
+  }
+  let normalizedQuery = bodyLines.join(' ').trim();
+  let derivedQuery = false;
+  if (!normalizedQuery) {
+    normalizedQuery = queryModes
+      .filter((entry) => entry.mode === 'term')
+      .map((entry) => entry.text)
+      .join(' ')
+      .trim();
+    if (!normalizedQuery) {
+      normalizedQuery = queryModes
+        .filter((entry) => entry.mode === 'intent')
+        .map((entry) => entry.text)
+        .join(' ')
+        .trim();
+    }
+    derivedQuery = normalizedQuery.length > 0;
+  }
+  if (!normalizedQuery) {
+    throw new Error(
+      'Structured query documents must include at least one plain query line, term line, or intent line. hyde-only documents are not allowed.',
+    );
+  }
+
+  return {
+    query: normalizedQuery,
+    queryModes: combinedQueryModes,
+    usedStructuredQuerySyntax: true,
+    derivedQuery,
+  };
+}
+
+export function buildExpansionFromQueryModes(queryModes: QueryModeInput[]): ExpansionResult | null {
+  if (queryModes.length === 0) return null;
+  const valid = validateQueryModeShape(queryModes);
+  const lexicalQueries = dedupeStrings(
+    valid.filter((entry) => entry.mode === 'term').map((entry) => entry.text),
+  ).slice(0, MAX_VARIANTS);
+  const vectorQueries = dedupeStrings(
+    valid.filter((entry) => entry.mode === 'intent').map((entry) => entry.text),
+  ).slice(0, MAX_VARIANTS);
+  const hyde = valid.find((entry) => entry.mode === 'hyde')?.text;
+  return { lexicalQueries, vectorQueries, ...(hyde ? { hyde } : {}) };
+}
+
 export function applyExpansionGuardrails(
   query: string,
   expansion: ExpansionResult,
@@ -321,6 +501,19 @@ export async function routeExpandedQueries(
   bm25ProbeResults: Bm25SignalResult[],
 ): Promise<RoutedQueries> {
   const original = query.trim();
+  const queryModeExpansion = buildExpansionFromQueryModes(options.queryModes ?? []);
+  if (queryModeExpansion) {
+    return {
+      bm25Queries: dedupeStrings([original, ...queryModeExpansion.lexicalQueries]),
+      semanticQueries: dedupeStrings([
+        original,
+        ...queryModeExpansion.vectorQueries,
+        ...(queryModeExpansion.hyde ? [queryModeExpansion.hyde] : []),
+      ]),
+      expansion: queryModeExpansion,
+      skipped: null,
+    };
+  }
   if (!options.enabled) {
     return {
       bm25Queries: [original],

--- a/src/domain/search/search/expansion.ts
+++ b/src/domain/search/search/expansion.ts
@@ -43,11 +43,14 @@ export interface QueryModeInput {
   text: string;
 }
 
+export type QueryTextKind = 'plain' | 'term' | 'intent' | 'empty';
+
 export interface StructuredQueryNormalization {
   query: string;
   queryModes: QueryModeInput[];
   usedStructuredQuerySyntax: boolean;
   derivedQuery: boolean;
+  queryTextKind: QueryTextKind;
 }
 
 export interface ExpansionResult {
@@ -69,6 +72,7 @@ export interface QueryExpansionOptions {
   provider?: ExpansionProvider;
   timeoutMs?: number;
   queryModes?: QueryModeInput[];
+  queryTextKind?: QueryTextKind;
 }
 
 export interface RoutedQueries {
@@ -285,18 +289,32 @@ export function normalizeStructuredQueryInput(
   explicitQueryModes: QueryModeInput[] = [],
 ): StructuredQueryNormalization {
   const explicit = validateQueryModeShape(explicitQueryModes);
-  if (!query.includes('\n')) {
-    return { query, queryModes: explicit, usedStructuredQuerySyntax: false, derivedQuery: false };
-  }
+  const trimmedQuery = query.trim();
+  const plainResult = (): StructuredQueryNormalization => {
+    if (!trimmedQuery && explicit.length > 0 && explicit.every((entry) => entry.mode === 'hyde')) {
+      throw new Error('HyDE-only inputs are not allowed; include a plain query, term, or intent.');
+    }
+    return {
+      query,
+      queryModes: explicit,
+      usedStructuredQuerySyntax: false,
+      derivedQuery: false,
+      queryTextKind: trimmedQuery ? 'plain' : 'empty',
+    };
+  };
 
   const nonBlankLines = query.split(/\r?\n/).filter((line) => line.trim().length > 0);
   if (nonBlankLines.length === 0) {
-    return { query, queryModes: explicit, usedStructuredQuerySyntax: false, derivedQuery: false };
+    return plainResult();
   }
 
   const hasTypedLine = nonBlankLines.some((line) => ANY_PREFIX_PATTERN.test(line.trim()));
   if (!hasTypedLine) {
-    return { query, queryModes: explicit, usedStructuredQuerySyntax: false, derivedQuery: false };
+    return plainResult();
+  }
+
+  if (!query.includes('\n') && !RECOGNIZED_PREFIX_PATTERN.test(trimmedQuery)) {
+    return plainResult();
   }
 
   const queryModes: QueryModeInput[] = [];
@@ -346,18 +364,22 @@ export function normalizeStructuredQueryInput(
   }
   let normalizedQuery = bodyLines.join(' ').trim();
   let derivedQuery = false;
+  let queryTextKind: QueryTextKind = normalizedQuery ? 'plain' : 'empty';
   if (!normalizedQuery) {
     normalizedQuery = queryModes
       .filter((entry) => entry.mode === 'term')
       .map((entry) => entry.text)
       .join(' ')
       .trim();
-    if (!normalizedQuery) {
+    if (normalizedQuery) {
+      queryTextKind = 'term';
+    } else {
       normalizedQuery = queryModes
         .filter((entry) => entry.mode === 'intent')
         .map((entry) => entry.text)
         .join(' ')
         .trim();
+      if (normalizedQuery) queryTextKind = 'intent';
     }
     derivedQuery = normalizedQuery.length > 0;
   }
@@ -372,6 +394,7 @@ export function normalizeStructuredQueryInput(
     queryModes: combinedQueryModes,
     usedStructuredQuerySyntax: true,
     derivedQuery,
+    queryTextKind,
   };
 }
 
@@ -501,12 +524,19 @@ export async function routeExpandedQueries(
   bm25ProbeResults: Bm25SignalResult[],
 ): Promise<RoutedQueries> {
   const original = query.trim();
-  const queryModeExpansion = buildExpansionFromQueryModes(options.queryModes ?? []);
+  const queryModes = options.queryModes ?? [];
+  if (!original && queryModes.length > 0 && queryModes.every((entry) => entry.mode === 'hyde')) {
+    throw new Error('HyDE-only inputs are not allowed; include a plain query, term, or intent.');
+  }
+  const queryModeExpansion = buildExpansionFromQueryModes(queryModes);
   if (queryModeExpansion) {
+    const queryTextKind = options.queryTextKind ?? (original ? 'plain' : 'empty');
+    const baseBm25 = queryTextKind === 'plain' || queryTextKind === 'term' ? [original] : [];
+    const baseSemantic = queryTextKind === 'plain' || queryTextKind === 'intent' ? [original] : [];
     return {
-      bm25Queries: dedupeStrings([original, ...queryModeExpansion.lexicalQueries]),
+      bm25Queries: dedupeStrings([...baseBm25, ...queryModeExpansion.lexicalQueries]),
       semanticQueries: dedupeStrings([
-        original,
+        ...baseSemantic,
         ...queryModeExpansion.vectorQueries,
         ...(queryModeExpansion.hyde ? [queryModeExpansion.hyde] : []),
       ]),

--- a/src/domain/search/search/expansion.ts
+++ b/src/domain/search/search/expansion.ts
@@ -97,16 +97,31 @@ function extractOverlapTokens(text: string): Set<string> {
   );
 }
 
+function stripNegationSpans(query: string): string {
+  return query.replace(NEGATION_PATTERN, ' ');
+}
+
 function stripAnchorSpans(query: string): string {
-  return query.replace(QUOTED_PHRASE_PATTERN, ' ').replace(NEGATION_PATTERN, ' ');
+  return stripNegationSpans(query).replace(QUOTED_PHRASE_PATTERN, ' ');
 }
 
 function extractQuerySignals(query: string): QuerySignals {
+  const negationMatches = [...query.matchAll(NEGATION_PATTERN)];
+  const negationSpans = negationMatches.map((match) => ({
+    start: match.index ?? 0,
+    end: (match.index ?? 0) + match[0].length,
+  }));
   const quotedPhrases = dedupeStrings(
-    [...query.matchAll(QUOTED_PHRASE_PATTERN)].map((match) => match[1]?.trim() ?? ''),
+    [...query.matchAll(QUOTED_PHRASE_PATTERN)]
+      .filter((match) => {
+        const start = match.index ?? 0;
+        const end = start + match[0].length;
+        return !negationSpans.some((span) => start >= span.start && end <= span.end);
+      })
+      .map((match) => match[1]?.trim() ?? ''),
   );
   const negations = dedupeStrings(
-    [...query.matchAll(NEGATION_PATTERN)].map((match) => {
+    negationMatches.map((match) => {
       const phrase = match[2]?.trim();
       if (phrase) return `-"${phrase}"`;
       const token = match[3]?.trim();
@@ -147,7 +162,7 @@ function hasPositiveNegatedValue(candidate: string, negation: string): boolean {
 }
 
 function contradictsNegation(signals: QuerySignals, candidate: string): boolean {
-  const candidateWithoutNegations = stripAnchorSpans(candidate);
+  const candidateWithoutNegations = stripNegationSpans(candidate);
   return signals.negations.some((negation) =>
     hasPositiveNegatedValue(candidateWithoutNegations, negation),
   );

--- a/src/domain/search/search/expansion.ts
+++ b/src/domain/search/search/expansion.ts
@@ -99,6 +99,10 @@ function extractOverlapTokens(text: string): Set<string> {
   );
 }
 
+function stripAnchorSpans(query: string): string {
+  return query.replace(QUOTED_PHRASE_PATTERN, ' ').replace(NEGATION_PATTERN, ' ');
+}
+
 function extractQuerySignals(query: string): QuerySignals {
   const quotedPhrases = dedupeStrings(
     [...query.matchAll(QUOTED_PHRASE_PATTERN)].map((match) => match[1]?.trim() ?? ''),
@@ -112,7 +116,7 @@ function extractQuerySignals(query: string): QuerySignals {
     }),
   );
   const criticalEntities = dedupeStrings(
-    (query.match(TOKEN_PATTERN) ?? []).filter(
+    (stripAnchorSpans(query).match(TOKEN_PATTERN) ?? []).filter(
       (token) => /[A-Z]/.test(token) || /[+#.]/.test(token) || /[A-Za-z]\d|\d[A-Za-z]/.test(token),
     ),
   );
@@ -123,14 +127,51 @@ function hasCaseInsensitiveSubstring(text: string, part: string): boolean {
   return text.toLowerCase().includes(part.toLowerCase());
 }
 
-function hasSufficientOverlap(signals: QuerySignals, candidate: string): boolean {
-  if (!candidate.trim()) return false;
-  for (const phrase of signals.quotedPhrases)
-    if (hasCaseInsensitiveSubstring(candidate, phrase)) return true;
+function parseNegationValue(negation: string): string {
+  if (negation.startsWith('-"') && negation.endsWith('"')) return negation.slice(2, -1);
+  return negation.slice(1);
+}
+
+function hasNegationAnchor(candidate: string, negation: string): boolean {
+  return candidate.includes(negation);
+}
+
+function hasPositiveNegatedValue(candidate: string, negation: string): boolean {
+  const value = parseNegationValue(negation);
+  if (!value) return false;
+  const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|[^A-Za-z0-9_#.+-])${escaped}($|[^A-Za-z0-9_#.+-])`, 'i').test(candidate);
+}
+
+function contradictsNegation(signals: QuerySignals, candidate: string): boolean {
+  return signals.negations.some(
+    (negation) =>
+      !hasNegationAnchor(candidate, negation) && hasPositiveNegatedValue(candidate, negation),
+  );
+}
+
+function hasRequiredAnchors(
+  signals: QuerySignals,
+  candidate: string,
+  exactLexical: boolean,
+): boolean {
+  if (!candidate.trim() || contradictsNegation(signals, candidate)) return false;
+  for (const phrase of signals.quotedPhrases) {
+    if (exactLexical) {
+      if (!candidate.includes(`"${phrase}"`)) return false;
+    } else if (!hasCaseInsensitiveSubstring(candidate, phrase)) return false;
+  }
   for (const negation of signals.negations)
-    if (hasCaseInsensitiveSubstring(candidate, negation)) return true;
-  for (const entity of signals.criticalEntities)
-    if (hasCaseInsensitiveSubstring(candidate, entity)) return true;
+    if (!hasNegationAnchor(candidate, negation)) return false;
+  for (const entity of signals.criticalEntities) if (!candidate.includes(entity)) return false;
+  return true;
+}
+
+function hasSufficientOverlap(signals: QuerySignals, candidate: string): boolean {
+  if (!candidate.trim() || contradictsNegation(signals, candidate)) return false;
+  if ([...signals.quotedPhrases, ...signals.negations, ...signals.criticalEntities].length > 0) {
+    return hasRequiredAnchors(signals, candidate, false);
+  }
   for (const token of extractOverlapTokens(candidate))
     if (signals.overlapTokens.has(token)) return true;
   return false;
@@ -154,7 +195,11 @@ export function applyExpansionGuardrails(
     buildAnchorLexicalQuery(query, signals),
     ...expansion.lexicalQueries,
   ])
-    .filter((variant) => hasSufficientOverlap(signals, variant))
+    .filter((variant) =>
+      [...signals.quotedPhrases, ...signals.negations, ...signals.criticalEntities].length > 0
+        ? hasRequiredAnchors(signals, variant, true)
+        : hasSufficientOverlap(signals, variant),
+    )
     .slice(0, MAX_VARIANTS);
   const vector = dedupeStrings(expansion.vectorQueries)
     .filter((variant) => hasSufficientOverlap(signals, variant))
@@ -252,7 +297,7 @@ export function hasStrongExactBm25Signal(query: string, results: Bm25SignalResul
   const normalizedQuery = normalizeExactQuery(query);
   const exactName = top.name?.toLowerCase() === normalizedQuery;
   const gap = top.bm25Score - (second?.bm25Score ?? 0);
-  return hasStrongBm25Signal(results) || Boolean(exactName && top.bm25Score > 0 && gap > 0);
+  return Boolean(exactName && top.bm25Score > 0 && gap > 0);
 }
 
 export async function routeExpandedQueries(

--- a/src/domain/search/search/expansion.ts
+++ b/src/domain/search/search/expansion.ts
@@ -1,6 +1,7 @@
 const JSON_EXTRACT_PATTERN = /\{[\s\S]*?\}/;
 const QUOTED_PHRASE_PATTERN = /"([^"]+)"/g;
-const NEGATION_PATTERN = /(^|[\s([{,.;:!?])-(?:"([^"]+)"|([^\s)\]},.;:!?]+))/g;
+const NEGATION_PATTERN =
+  /(^|[\s([{,.;:!?])-(?:"([^"]+)"|([A-Za-z0-9_+#-](?:[A-Za-z0-9_+#-]|\.(?=[A-Za-z0-9_+#-]))*))/g;
 const TOKEN_PATTERN = /[A-Za-z0-9][A-Za-z0-9.+#_-]*/g;
 const MAX_VARIANTS = 5;
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -158,7 +159,10 @@ function hasPositiveNegatedValue(candidate: string, negation: string): boolean {
   const value = parseNegationValue(negation);
   if (!value) return false;
   const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`(^|[^A-Za-z0-9_#.+-])${escaped}($|[^A-Za-z0-9_#.+-])`, 'i').test(candidate);
+  return new RegExp(
+    `(^|[^A-Za-z0-9_#.+-])${escaped}(?=$|[^A-Za-z0-9_#.+-]|\\.(?:$|\\s))`,
+    'i',
+  ).test(candidate);
 }
 
 function contradictsNegation(signals: QuerySignals, candidate: string): boolean {

--- a/src/domain/search/search/expansion.ts
+++ b/src/domain/search/search/expansion.ts
@@ -1,11 +1,9 @@
 const JSON_EXTRACT_PATTERN = /\{[\s\S]*?\}/;
 const QUOTED_PHRASE_PATTERN = /"([^"]+)"/g;
-const NEGATION_PATTERN = /-(?:"([^"]+)"|([^\s]+))/g;
+const NEGATION_PATTERN = /(^|[\s([{,.;:!?])-(?:"([^"]+)"|([^\s)\]},.;:!?]+))/g;
 const TOKEN_PATTERN = /[A-Za-z0-9][A-Za-z0-9.+#_-]*/g;
 const MAX_VARIANTS = 5;
 const DEFAULT_TIMEOUT_MS = 5000;
-const STRONG_BM25_MIN_SCORE = 0.84;
-const STRONG_BM25_MIN_GAP = 0.14;
 const STOPWORDS = new Set([
   'a',
   'an',
@@ -109,15 +107,16 @@ function extractQuerySignals(query: string): QuerySignals {
   );
   const negations = dedupeStrings(
     [...query.matchAll(NEGATION_PATTERN)].map((match) => {
-      const phrase = match[1]?.trim();
+      const phrase = match[2]?.trim();
       if (phrase) return `-"${phrase}"`;
-      const token = match[2]?.trim();
+      const token = match[3]?.trim();
       return token ? `-${token}` : '';
     }),
   );
   const criticalEntities = dedupeStrings(
     (stripAnchorSpans(query).match(TOKEN_PATTERN) ?? []).filter(
-      (token) => /[A-Z]/.test(token) || /[+#.]/.test(token) || /[A-Za-z]\d|\d[A-Za-z]/.test(token),
+      (token) =>
+        /[A-Z]/.test(token) || /[_.+#-]/.test(token) || /[A-Za-z]\d|\d[A-Za-z]/.test(token),
     ),
   );
   return { quotedPhrases, negations, criticalEntities, overlapTokens: extractOverlapTokens(query) };
@@ -133,7 +132,11 @@ function parseNegationValue(negation: string): string {
 }
 
 function hasNegationAnchor(candidate: string, negation: string): boolean {
-  return candidate.includes(negation);
+  const value = parseNegationValue(negation);
+  if (!value) return false;
+  const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const negatedValue = negation.startsWith('-"') ? `"${escaped}"` : escaped;
+  return new RegExp(`(^|[\\s([{,.;:!?])-${negatedValue}($|[\\s)\\]},.;:!?])`).test(candidate);
 }
 
 function hasPositiveNegatedValue(candidate: string, negation: string): boolean {
@@ -144,9 +147,9 @@ function hasPositiveNegatedValue(candidate: string, negation: string): boolean {
 }
 
 function contradictsNegation(signals: QuerySignals, candidate: string): boolean {
-  return signals.negations.some(
-    (negation) =>
-      !hasNegationAnchor(candidate, negation) && hasPositiveNegatedValue(candidate, negation),
+  const candidateWithoutNegations = stripAnchorSpans(candidate);
+  return signals.negations.some((negation) =>
+    hasPositiveNegatedValue(candidateWithoutNegations, negation),
   );
 }
 
@@ -282,13 +285,6 @@ function normalizeExactQuery(query: string): string {
     .trim()
     .replace(/^"(.*)"$/, '$1')
     .toLowerCase();
-}
-
-export function hasStrongBm25Signal(results: Bm25SignalResult[]): boolean {
-  const [top, second] = results;
-  if (!top) return false;
-  const gap = top.bm25Score - (second?.bm25Score ?? 0);
-  return top.bm25Score >= STRONG_BM25_MIN_SCORE && gap >= STRONG_BM25_MIN_GAP;
 }
 
 export function hasStrongExactBm25Signal(query: string, results: Bm25SignalResult[]): boolean {

--- a/src/domain/search/search/fusion.ts
+++ b/src/domain/search/search/fusion.ts
@@ -9,6 +9,7 @@ export interface WeightedRrfConfig {
   weights: FusionWeights;
   topRankBonus: number;
   topRankThreshold: number;
+  nearTopRankBonusMultiplier: number;
 }
 
 export interface RankedFusionResult<TPayload = unknown> {
@@ -132,7 +133,7 @@ export function weightedRrfFuse<TPayload = unknown>(
     if (ranks.some((rank) => rank === 1)) {
       candidate.topRankBonus = config.topRankBonus;
     } else if (ranks.some((rank) => rank <= config.topRankThreshold)) {
-      candidate.topRankBonus = config.topRankBonus * 0.4;
+      candidate.topRankBonus = config.topRankBonus * config.nearTopRankBonusMultiplier;
     }
     candidate.score += candidate.topRankBonus;
   }

--- a/src/domain/search/search/fusion.ts
+++ b/src/domain/search/search/fusion.ts
@@ -1,0 +1,153 @@
+export type FusionSource = 'bm25' | 'bm25_variant' | 'vector' | 'vector_variant' | 'hyde';
+
+export type FusionStage = 'bm25' | 'vector';
+
+export type FusionWeights = Partial<Record<FusionSource, number>>;
+
+export interface WeightedRrfConfig {
+  k: number;
+  weights: FusionWeights;
+  topRankBonus: number;
+  topRankThreshold: number;
+}
+
+export interface RankedFusionResult<TPayload = unknown> {
+  key: string;
+  rank: number;
+  payload?: TPayload;
+}
+
+export interface RankedFusionInput<TPayload = unknown> {
+  source: FusionSource;
+  query: string;
+  results: RankedFusionResult<TPayload>[];
+}
+
+export interface FusionSourceContribution {
+  source: FusionSource;
+  stage: FusionStage;
+  query: string;
+  rank: number;
+  weight: number;
+  contribution: number;
+}
+
+export interface FusionExplain {
+  sources: FusionSourceContribution[];
+  topRankBonus: number;
+}
+
+export interface FusedResult<TPayload = unknown> {
+  key: string;
+  score: number;
+  bm25Rank: number | null;
+  semanticRank: number | null;
+  payload?: TPayload;
+  explain: FusionExplain;
+}
+
+interface FusionAccumulator<TPayload> {
+  key: string;
+  score: number;
+  bm25Rank: number | null;
+  semanticRank: number | null;
+  payload?: TPayload;
+  sources: FusionSourceContribution[];
+  topRankBonus: number;
+}
+
+export function fusionStage(source: FusionSource): FusionStage {
+  return source === 'bm25' || source === 'bm25_variant' ? 'bm25' : 'vector';
+}
+
+function contribution(rank: number, k: number, weight: number): number {
+  return weight / (k + rank);
+}
+
+function weightForSource(source: FusionSource, weights: FusionWeights): number {
+  return weights[source] ?? 1;
+}
+
+function compareByScoreThenKey<TPayload>(
+  a: FusedResult<TPayload>,
+  b: FusedResult<TPayload>,
+): number {
+  const scoreDiff = b.score - a.score;
+  if (Math.abs(scoreDiff) > 1e-12) return scoreDiff;
+  return a.key.localeCompare(b.key);
+}
+
+export function weightedRrfFuse<TPayload = unknown>(
+  inputs: RankedFusionInput<TPayload>[],
+  config: WeightedRrfConfig,
+): FusedResult<TPayload>[] {
+  const candidates = new Map<string, FusionAccumulator<TPayload>>();
+
+  for (const input of inputs) {
+    const sourceWeight = weightForSource(input.source, config.weights);
+    const stage = fusionStage(input.source);
+    for (const result of input.results) {
+      let candidate = candidates.get(result.key);
+      if (!candidate) {
+        candidate = {
+          key: result.key,
+          score: 0,
+          bm25Rank: null,
+          semanticRank: null,
+          payload: result.payload,
+          sources: [],
+          topRankBonus: 0,
+        };
+        candidates.set(result.key, candidate);
+      }
+      if (candidate.payload === undefined && result.payload !== undefined) {
+        candidate.payload = result.payload;
+      }
+
+      const amount = contribution(result.rank, config.k, sourceWeight);
+      candidate.score += amount;
+      candidate.sources.push({
+        source: input.source,
+        stage,
+        query: input.query,
+        rank: result.rank,
+        weight: sourceWeight,
+        contribution: amount,
+      });
+
+      if (stage === 'bm25') {
+        if (candidate.bm25Rank === null || result.rank < candidate.bm25Rank) {
+          candidate.bm25Rank = result.rank;
+        }
+      } else if (candidate.semanticRank === null || result.rank < candidate.semanticRank) {
+        candidate.semanticRank = result.rank;
+      }
+    }
+  }
+
+  for (const candidate of candidates.values()) {
+    const ranks = [candidate.bm25Rank, candidate.semanticRank].filter(
+      (rank): rank is number => rank !== null,
+    );
+    if (ranks.some((rank) => rank === 1)) {
+      candidate.topRankBonus = config.topRankBonus;
+    } else if (ranks.some((rank) => rank <= config.topRankThreshold)) {
+      candidate.topRankBonus = config.topRankBonus * 0.4;
+    }
+    candidate.score += candidate.topRankBonus;
+  }
+
+  return [...candidates.values()]
+    .map((candidate) => ({
+      key: candidate.key,
+      score: candidate.score,
+      bm25Rank: candidate.bm25Rank,
+      semanticRank: candidate.semanticRank,
+      payload: candidate.payload,
+      explain: {
+        sources: candidate.sources,
+        topRankBonus: candidate.topRankBonus,
+      },
+    }))
+    .sort(compareByScoreThenKey);
+}

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -1,6 +1,7 @@
 import { openReadonlyOrFail } from '../../../db/index.js';
 import { DEFAULTS, loadConfig } from '../../../infrastructure/config.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
+import { resolveModelRoleUri } from '../models.js';
 import { hasFtsIndex } from '../stores/fts5.js';
 import { routeExpandedQueries } from './expansion.js';
 import {
@@ -12,6 +13,7 @@ import {
 } from './fusion.js';
 import { ftsSearchData } from './keyword.js';
 import {
+  createDefaultRerankPort,
   type RerankCandidate,
   type RerankExplain,
   type RerankPort,
@@ -59,6 +61,11 @@ interface RankedPayload {
   fileHash?: string | null;
   bm25Score?: number;
   similarity?: number;
+  content?: string;
+  text_preview?: string;
+  textPreview?: string;
+  full_text?: string;
+  fullText?: string;
 }
 
 /** Parse a semicolon-delimited query string into individual queries. */
@@ -221,17 +228,82 @@ function mapFusedResult(
 }
 
 /** Apply cross-encoder reranking to fused results if a rerank port is available. */
+function bestRerankText(payload: RankedPayload | undefined): string | undefined {
+  if (!payload) return undefined;
+  const candidates = [
+    payload.full_text,
+    payload.fullText,
+    payload.text_preview,
+    payload.textPreview,
+    payload.content,
+  ];
+  return candidates.find((text) => typeof text === 'string' && text.trim().length > 0);
+}
+
+function isOriginalPlainBm25TopHit(
+  fusedResult: { bm25Rank?: number | null; payload?: RankedPayload; explain: FusionExplain },
+  query: string,
+  opts: SemanticSearchOpts,
+): boolean {
+  const queryTextKind = opts.queryTextKind ?? 'plain';
+  const normalizedQuery = query.trim().toLowerCase();
+  const normalizedName = fusedResult.payload?.name.trim().toLowerCase();
+  return (
+    queryTextKind === 'plain' &&
+    normalizedQuery.length > 0 &&
+    normalizedQuery === normalizedName &&
+    fusedResult.bm25Rank === 1 &&
+    fusedResult.explain.sources.some(
+      (source) => source.source === 'bm25' && source.rank === 1 && source.query === query,
+    )
+  );
+}
+
+function bestRerankTextByKey(rankedLists: RankedFusionInput<RankedPayload>[]): Map<string, string> {
+  const textByKey = new Map<string, string>();
+  for (const field of [
+    'full_text',
+    'fullText',
+    'text_preview',
+    'textPreview',
+    'content',
+  ] as const) {
+    for (const list of rankedLists) {
+      for (const result of list.results) {
+        if (textByKey.has(result.key)) continue;
+        const text = result.payload?.[field];
+        if (typeof text === 'string' && text.trim().length > 0) {
+          textByKey.set(result.key, text);
+        }
+      }
+    }
+  }
+  return textByKey;
+}
+
+interface AppliedReranking {
+  metaByKey: Map<string, RerankResultMeta>;
+  orderedKeys: string[] | null;
+}
+
 async function applyReranking(
-  fusedResults: Array<{ key: string; score: number; payload?: RankedPayload }>,
+  fusedResults: Array<{
+    key: string;
+    score: number;
+    bm25Rank?: number | null;
+    payload?: RankedPayload;
+    explain: FusionExplain;
+  }>,
   query: string,
   rerankPort: RerankPort | null | undefined,
   searchCfg: CodegraphConfig['search'],
   opts: SemanticSearchOpts,
-): Promise<Map<string, RerankResultMeta>> {
+  textByKey: Map<string, string>,
+): Promise<AppliedReranking> {
   const rerankMetaBykey = new Map<string, RerankResultMeta>();
 
   const rerankEnabled = searchCfg.rerank?.enabled ?? false;
-  if (!rerankPort || !rerankEnabled) return rerankMetaBykey;
+  if (!rerankPort || !rerankEnabled) return { metaByKey: rerankMetaBykey, orderedKeys: null };
 
   const maxCandidates =
     searchCfg.rerank?.maxCandidates ?? DEFAULTS.search.rerank?.maxCandidates ?? 20;
@@ -247,7 +319,9 @@ async function applyReranking(
     file: (r.payload as RankedPayload | undefined)?.file ?? '',
     line: (r.payload as RankedPayload | undefined)?.line ?? 0,
     fusionScore: r.score,
-    bm25Rank: null, // Will be filled from metrics in the caller context
+    bm25Rank: r.bm25Rank ?? null,
+    lexicalExactTopHit: isOriginalPlainBm25TopHit(r, query, opts),
+    text: textByKey.get(r.key) ?? bestRerankText(r.payload),
   }));
 
   // Build intent from query modes if available
@@ -276,7 +350,12 @@ async function applyReranking(
     });
   }
 
-  return rerankMetaBykey;
+  return {
+    metaByKey: rerankMetaBykey,
+    orderedKeys: rerankOutput.reranked
+      ? rerankOutput.candidates.map((candidate) => candidate.key)
+      : null,
+  };
 }
 
 export async function hybridSearchData(
@@ -296,6 +375,7 @@ export async function hybridSearchData(
 
   const queries = parseQueries(query);
   const rankedLists = await collectRankedLists(queries, customDbPath, opts, topK);
+  const textByKey = bestRerankTextByKey(rankedLists);
   const fused = weightedRrfFuse(rankedLists, {
     k: opts.rrfK ?? searchCfg.rrfK,
     weights: weightsFromConfig(searchCfg),
@@ -305,15 +385,33 @@ export async function hybridSearchData(
       searchCfg.nearTopRankBonusMultiplier ?? DEFAULTS.search.nearTopRankBonusMultiplier,
   });
 
-  // Apply reranking if port provided and enabled
-  const rerankPort = (opts as SemanticSearchOpts & { rerankPort?: RerankPort }).rerankPort;
+  // Apply reranking when config enables it, using an injected port or safe default HTTP port.
+  let rerankPort = (opts as SemanticSearchOpts & { rerankPort?: RerankPort }).rerankPort;
   let rerankMetaBykey = new Map<string, RerankResultMeta>();
-  if (rerankPort && (searchCfg.rerank?.enabled ?? false)) {
-    rerankMetaBykey = await applyReranking(fused, query, rerankPort, searchCfg, opts);
+  let orderedRerankKeys: string[] | null = null;
+  if (searchCfg.rerank?.enabled ?? false) {
+    if (!rerankPort) {
+      rerankPort = createDefaultRerankPort(resolveModelRoleUri(config, 'rerank')) ?? undefined;
+    }
+    if (rerankPort) {
+      const applied = await applyReranking(fused, query, rerankPort, searchCfg, opts, textByKey);
+      rerankMetaBykey = applied.metaByKey;
+      orderedRerankKeys = applied.orderedKeys;
+    }
   }
 
   const metrics = metricsFromRankedLists(rankedLists);
-  const results = fused
+  const fusedByKey = new Map(fused.map((result) => [result.key, result]));
+  const orderedFused = orderedRerankKeys
+    ? [
+        ...orderedRerankKeys.flatMap((key) => {
+          const result = fusedByKey.get(key);
+          return result ? [result] : [];
+        }),
+        ...fused.filter((result) => !orderedRerankKeys.includes(result.key)),
+      ]
+    : fused;
+  const results = orderedFused
     .slice(0, limit)
     .map((result) =>
       mapFusedResult(

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -75,15 +75,18 @@ async function collectRankedLists(
 
   for (const q of queries) {
     const expansionEnabled = opts.expand ?? false;
-    const bm25Probe = expansionEnabled
-      ? ftsSearchData(q, customDbPath, { ...opts, limit: Math.min(topK, 5) })
-      : null;
+    const hasStructuredModes = (opts.queryModes?.length ?? 0) > 0;
+    const bm25Probe =
+      expansionEnabled && !hasStructuredModes
+        ? ftsSearchData(q, customDbPath, { ...opts, limit: Math.min(topK, 5) })
+        : null;
     const routed = await routeExpandedQueries(
       q,
       {
         enabled: expansionEnabled,
         provider: opts.expansionProvider,
         timeoutMs: opts.expansionTimeoutMs,
+        queryModes: opts.queryModes,
       },
       bm25Probe?.results ?? [],
     );

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -74,11 +74,14 @@ async function collectRankedLists(
   const rankedLists: RankedItem[][] = [];
 
   for (const q of queries) {
-    const bm25Probe = ftsSearchData(q, customDbPath, { ...opts, limit: Math.min(topK, 5) });
+    const expansionEnabled = opts.expand ?? false;
+    const bm25Probe = expansionEnabled
+      ? ftsSearchData(q, customDbPath, { ...opts, limit: Math.min(topK, 5) })
+      : null;
     const routed = await routeExpandedQueries(
       q,
       {
-        enabled: opts.expand ?? false,
+        enabled: expansionEnabled,
         provider: opts.expansionProvider,
         timeoutMs: opts.expansionTimeoutMs,
       },

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -11,8 +11,20 @@ import {
   weightedRrfFuse,
 } from './fusion.js';
 import { ftsSearchData } from './keyword.js';
+import {
+  type RerankCandidate,
+  type RerankExplain,
+  type RerankPort,
+  rerankCandidates,
+} from './rerank.js';
 import type { SemanticSearchOpts } from './semantic.js';
 import { searchData } from './semantic.js';
+
+interface RerankResultMeta {
+  rerankScore: number | null;
+  blendedScore: number;
+  rerankExplain?: RerankExplain;
+}
 
 interface HybridResult {
   name: string;
@@ -28,6 +40,8 @@ interface HybridResult {
   similarity: number | null;
   semanticRank: number | null;
   explain?: FusionExplain;
+  /** Rerank metadata — present only when reranking was applied */
+  rerank?: RerankResultMeta;
 }
 
 export interface HybridSearchResult {
@@ -185,6 +199,7 @@ function mapFusedResult(
   metrics: ResultMetrics | undefined,
   explain: FusionExplain,
   includeExplain: boolean,
+  rerankMeta?: RerankResultMeta,
 ): HybridResult {
   const payload = metrics?.payload;
   return {
@@ -201,31 +216,67 @@ function mapFusedResult(
     similarity: metrics?.similarity ?? null,
     semanticRank: metrics?.semanticRank ?? null,
     ...(includeExplain ? { explain } : {}),
+    ...(rerankMeta ? { rerank: rerankMeta } : {}),
   };
 }
 
-/** Weighted Reciprocal Rank Fusion: merge ranked lists into a single scored result set. */
-function fuseResults(
-  rankedLists: RankedFusionInput<RankedPayload>[],
-  config: CodegraphConfig['search'],
-  limit: number,
-  includeExplain: boolean,
-): HybridResult[] {
-  const fused = weightedRrfFuse(rankedLists, {
-    k: config.rrfK,
-    weights: weightsFromConfig(config),
-    topRankBonus: config.topRankBonus ?? 0,
-    topRankThreshold: config.topRankThreshold ?? 0,
-    nearTopRankBonusMultiplier:
-      config.nearTopRankBonusMultiplier ?? DEFAULTS.search.nearTopRankBonusMultiplier,
-  });
-  const metrics = metricsFromRankedLists(rankedLists);
+/** Apply cross-encoder reranking to fused results if a rerank port is available. */
+async function applyReranking(
+  fusedResults: Array<{ key: string; score: number; payload?: RankedPayload }>,
+  query: string,
+  rerankPort: RerankPort | null | undefined,
+  searchCfg: CodegraphConfig['search'],
+  opts: SemanticSearchOpts,
+): Promise<Map<string, RerankResultMeta>> {
+  const rerankMetaBykey = new Map<string, RerankResultMeta>();
 
-  return fused
-    .slice(0, limit)
-    .map((result) =>
-      mapFusedResult(result.score, metrics.get(result.key), result.explain, includeExplain),
-    );
+  const rerankEnabled = searchCfg.rerank?.enabled ?? false;
+  if (!rerankPort || !rerankEnabled) return rerankMetaBykey;
+
+  const maxCandidates =
+    searchCfg.rerank?.maxCandidates ?? DEFAULTS.search.rerank?.maxCandidates ?? 20;
+  const fusionWeight =
+    searchCfg.rerank?.fusionWeight ?? DEFAULTS.search.rerank?.fusionWeight ?? 0.4;
+  const rerankWeight =
+    searchCfg.rerank?.rerankWeight ?? DEFAULTS.search.rerank?.rerankWeight ?? 0.6;
+
+  const candidates: RerankCandidate[] = fusedResults.map((r) => ({
+    key: r.key,
+    name: (r.payload as RankedPayload | undefined)?.name ?? '',
+    kind: (r.payload as RankedPayload | undefined)?.kind ?? '',
+    file: (r.payload as RankedPayload | undefined)?.file ?? '',
+    line: (r.payload as RankedPayload | undefined)?.line ?? 0,
+    fusionScore: r.score,
+    bm25Rank: null, // Will be filled from metrics in the caller context
+  }));
+
+  // Build intent from query modes if available
+  const intentParts: string[] = [];
+  if (opts.queryModes) {
+    for (const qm of opts.queryModes) {
+      if (qm.mode === 'intent' && qm.text) {
+        intentParts.push(qm.text);
+      }
+    }
+  }
+  const intent = intentParts.length > 0 ? intentParts.join('; ') : undefined;
+
+  const rerankOutput = await rerankCandidates(rerankPort, query, candidates, {
+    maxCandidates,
+    fusionWeight,
+    rerankWeight,
+    intent,
+  });
+
+  for (const candidate of rerankOutput.candidates) {
+    rerankMetaBykey.set(candidate.key, {
+      rerankScore: candidate.rerankScore,
+      blendedScore: candidate.blendedScore,
+      rerankExplain: candidate.explain,
+    });
+  }
+
+  return rerankMetaBykey;
 }
 
 export async function hybridSearchData(
@@ -245,12 +296,34 @@ export async function hybridSearchData(
 
   const queries = parseQueries(query);
   const rankedLists = await collectRankedLists(queries, customDbPath, opts, topK);
-  const results = fuseResults(
-    rankedLists,
-    { ...searchCfg, rrfK: opts.rrfK ?? searchCfg.rrfK },
-    limit,
-    opts.explain ?? false,
-  );
+  const fused = weightedRrfFuse(rankedLists, {
+    k: opts.rrfK ?? searchCfg.rrfK,
+    weights: weightsFromConfig(searchCfg),
+    topRankBonus: searchCfg.topRankBonus ?? 0,
+    topRankThreshold: searchCfg.topRankThreshold ?? 0,
+    nearTopRankBonusMultiplier:
+      searchCfg.nearTopRankBonusMultiplier ?? DEFAULTS.search.nearTopRankBonusMultiplier,
+  });
+
+  // Apply reranking if port provided and enabled
+  const rerankPort = (opts as SemanticSearchOpts & { rerankPort?: RerankPort }).rerankPort;
+  let rerankMetaBykey = new Map<string, RerankResultMeta>();
+  if (rerankPort && (searchCfg.rerank?.enabled ?? false)) {
+    rerankMetaBykey = await applyReranking(fused, query, rerankPort, searchCfg, opts);
+  }
+
+  const metrics = metricsFromRankedLists(rankedLists);
+  const results = fused
+    .slice(0, limit)
+    .map((result) =>
+      mapFusedResult(
+        result.score,
+        metrics.get(result.key),
+        result.explain,
+        opts.explain ?? false,
+        rerankMetaBykey.get(result.key),
+      ),
+    );
 
   return { results };
 }

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -233,9 +233,9 @@ function bestRerankText(payload: RankedPayload | undefined): string | undefined 
   const candidates = [
     payload.full_text,
     payload.fullText,
+    payload.content,
     payload.text_preview,
     payload.textPreview,
-    payload.content,
   ];
   return candidates.find((text) => typeof text === 'string' && text.trim().length > 0);
 }
@@ -264,9 +264,9 @@ function bestRerankTextByKey(rankedLists: RankedFusionInput<RankedPayload>[]): M
   for (const field of [
     'full_text',
     'fullText',
+    'content',
     'text_preview',
     'textPreview',
-    'content',
   ] as const) {
     for (const list of rankedLists) {
       for (const result of list.results) {

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -302,8 +302,7 @@ async function applyReranking(
 ): Promise<AppliedReranking> {
   const rerankMetaBykey = new Map<string, RerankResultMeta>();
 
-  const rerankEnabled = searchCfg.rerank?.enabled ?? false;
-  if (!rerankPort || !rerankEnabled) return { metaByKey: rerankMetaBykey, orderedKeys: null };
+  if (!rerankPort) return { metaByKey: rerankMetaBykey, orderedKeys: null };
 
   const maxCandidates =
     opts.rerankCandidates ??
@@ -388,7 +387,7 @@ export async function hybridSearchData(
       searchCfg.nearTopRankBonusMultiplier ?? DEFAULTS.search.nearTopRankBonusMultiplier,
   });
 
-  // Apply reranking when config enables it, using an injected port or safe default HTTP port.
+  // Apply reranking when the effective request/config decision enables it, using an injected port or safe default HTTP port.
   let rerankPort = (opts as SemanticSearchOpts & { rerankPort?: RerankPort }).rerankPort;
   let rerankMetaBykey = new Map<string, RerankResultMeta>();
   let orderedRerankKeys: string[] | null = null;

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -1,5 +1,5 @@
 import { openReadonlyOrFail } from '../../../db/index.js';
-import { loadConfig } from '../../../infrastructure/config.js';
+import { DEFAULTS, loadConfig } from '../../../infrastructure/config.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
 import { hasFtsIndex } from '../stores/fts5.js';
 import { routeExpandedQueries } from './expansion.js';
@@ -216,6 +216,8 @@ function fuseResults(
     weights: weightsFromConfig(config),
     topRankBonus: config.topRankBonus ?? 0,
     topRankThreshold: config.topRankThreshold ?? 0,
+    nearTopRankBonusMultiplier:
+      config.nearTopRankBonusMultiplier ?? DEFAULTS.search.nearTopRankBonusMultiplier,
   });
   const metrics = metricsFromRankedLists(rankedLists);
 

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -2,6 +2,7 @@ import { openReadonlyOrFail } from '../../../db/index.js';
 import { loadConfig } from '../../../infrastructure/config.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
 import { hasFtsIndex } from '../stores/fts5.js';
+import { routeExpandedQueries } from './expansion.js';
 import { ftsSearchData } from './keyword.js';
 import type { SemanticSearchOpts } from './semantic.js';
 import { searchData } from './semantic.js';
@@ -73,32 +74,47 @@ async function collectRankedLists(
   const rankedLists: RankedItem[][] = [];
 
   for (const q of queries) {
-    const bm25Data = ftsSearchData(q, customDbPath, { ...opts, limit: topK });
-    if (bm25Data?.results) {
-      rankedLists.push(
-        bm25Data.results.map((r, idx) => ({
-          key: `${r.name}:${r.file}:${r.line}`,
-          rank: idx + 1,
-          source: 'bm25' as const,
-          ...r,
-        })),
-      );
+    const bm25Probe = ftsSearchData(q, customDbPath, { ...opts, limit: Math.min(topK, 5) });
+    const routed = await routeExpandedQueries(
+      q,
+      {
+        enabled: opts.expand ?? false,
+        provider: opts.expansionProvider,
+        timeoutMs: opts.expansionTimeoutMs,
+      },
+      bm25Probe?.results ?? [],
+    );
+
+    for (const bm25Query of routed.bm25Queries) {
+      const bm25Data = ftsSearchData(bm25Query, customDbPath, { ...opts, limit: topK });
+      if (bm25Data?.results) {
+        rankedLists.push(
+          bm25Data.results.map((r, idx) => ({
+            key: `${r.name}:${r.file}:${r.line}`,
+            rank: idx + 1,
+            source: 'bm25' as const,
+            ...r,
+          })),
+        );
+      }
     }
 
-    const semData = await searchData(q, customDbPath, {
-      ...opts,
-      limit: topK,
-      minScore: opts.minScore ?? 0.2,
-    });
-    if (semData?.results) {
-      rankedLists.push(
-        semData.results.map((r, idx) => ({
-          key: `${r.name}:${r.file}:${r.line}`,
-          rank: idx + 1,
-          source: 'semantic' as const,
-          ...r,
-        })),
-      );
+    for (const semanticQuery of routed.semanticQueries) {
+      const semData = await searchData(semanticQuery, customDbPath, {
+        ...opts,
+        limit: topK,
+        minScore: opts.minScore ?? 0.2,
+      });
+      if (semData?.results) {
+        rankedLists.push(
+          semData.results.map((r, idx) => ({
+            key: `${r.name}:${r.file}:${r.line}`,
+            rank: idx + 1,
+            source: 'semantic' as const,
+            ...r,
+          })),
+        );
+      }
     }
   }
 

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -3,6 +3,13 @@ import { loadConfig } from '../../../infrastructure/config.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
 import { hasFtsIndex } from '../stores/fts5.js';
 import { routeExpandedQueries } from './expansion.js';
+import {
+  type FusionExplain,
+  type FusionSource,
+  type FusionWeights,
+  type RankedFusionInput,
+  weightedRrfFuse,
+} from './fusion.js';
 import { ftsSearchData } from './keyword.js';
 import type { SemanticSearchOpts } from './semantic.js';
 import { searchData } from './semantic.js';
@@ -20,16 +27,15 @@ interface HybridResult {
   bm25Rank: number | null;
   similarity: number | null;
   semanticRank: number | null;
+  explain?: FusionExplain;
 }
 
 export interface HybridSearchResult {
   results: HybridResult[];
 }
 
-interface RankedItem {
-  key: string;
-  rank: number;
-  source: 'bm25' | 'semantic';
+interface RankedPayload {
+  source: FusionSource;
   name: string;
   kind: string;
   file: string;
@@ -39,21 +45,6 @@ interface RankedItem {
   fileHash?: string | null;
   bm25Score?: number;
   similarity?: number;
-}
-
-interface FusionEntry {
-  name: string;
-  kind: string;
-  file: string;
-  line: number;
-  endLine: number | null;
-  role: string | null;
-  fileHash: string | null;
-  rrfScore: number;
-  bm25Score: number | null;
-  bm25Rank: number | null;
-  similarity: number | null;
-  semanticRank: number | null;
 }
 
 /** Parse a semicolon-delimited query string into individual queries. */
@@ -70,10 +61,11 @@ async function collectRankedLists(
   customDbPath: string | undefined,
   opts: SemanticSearchOpts,
   topK: number,
-): Promise<RankedItem[][]> {
-  const rankedLists: RankedItem[][] = [];
+): Promise<RankedFusionInput<RankedPayload>[]> {
+  const rankedLists: RankedFusionInput<RankedPayload>[] = [];
 
   for (const q of queries) {
+    const original = q.trim();
     const expansionEnabled = opts.expand ?? false;
     const hasStructuredModes = (opts.queryModes?.length ?? 0) > 0;
     const bm25Probe =
@@ -91,36 +83,49 @@ async function collectRankedLists(
       },
       bm25Probe?.results ?? [],
     );
+    const queryTextKind = opts.queryTextKind ?? 'plain';
 
     for (const bm25Query of routed.bm25Queries) {
+      const source: FusionSource =
+        bm25Query === original && (queryTextKind === 'plain' || queryTextKind === 'term')
+          ? 'bm25'
+          : 'bm25_variant';
       const bm25Data = ftsSearchData(bm25Query, customDbPath, { ...opts, limit: topK });
       if (bm25Data?.results) {
-        rankedLists.push(
-          bm25Data.results.map((r, idx) => ({
-            key: `${r.name}:${r.file}:${r.line}`,
+        rankedLists.push({
+          source,
+          query: bm25Query,
+          results: bm25Data.results.map((result, idx) => ({
+            key: `${result.name}:${result.file}:${result.line}`,
             rank: idx + 1,
-            source: 'bm25' as const,
-            ...r,
+            payload: { source, ...result },
           })),
-        );
+        });
       }
     }
 
     for (const semanticQuery of routed.semanticQueries) {
+      const source: FusionSource =
+        routed.expansion?.hyde && semanticQuery === routed.expansion.hyde
+          ? 'hyde'
+          : semanticQuery === original && (queryTextKind === 'plain' || queryTextKind === 'intent')
+            ? 'vector'
+            : 'vector_variant';
       const semData = await searchData(semanticQuery, customDbPath, {
         ...opts,
         limit: topK,
         minScore: opts.minScore ?? 0.2,
       });
       if (semData?.results) {
-        rankedLists.push(
-          semData.results.map((r, idx) => ({
-            key: `${r.name}:${r.file}:${r.line}`,
+        rankedLists.push({
+          source,
+          query: semanticQuery,
+          results: semData.results.map((result, idx) => ({
+            key: `${result.name}:${result.file}:${result.line}`,
             rank: idx + 1,
-            source: 'semantic' as const,
-            ...r,
+            payload: { source, ...result },
           })),
-        );
+        });
       }
     }
   }
@@ -128,61 +133,97 @@ async function collectRankedLists(
   return rankedLists;
 }
 
-/** Reciprocal Rank Fusion: merge ranked lists into a single scored result set. */
-function fuseResults(rankedLists: RankedItem[][], k: number, limit: number): HybridResult[] {
-  const fusionMap = new Map<string, FusionEntry>();
+function weightsFromConfig(searchCfg: CodegraphConfig['search']): FusionWeights {
+  return {
+    bm25: searchCfg.rrfWeights?.bm25,
+    bm25_variant: searchCfg.rrfWeights?.bm25Variant,
+    vector: searchCfg.rrfWeights?.vector,
+    vector_variant: searchCfg.rrfWeights?.vectorVariant,
+    hyde: searchCfg.rrfWeights?.hyde,
+  };
+}
 
+interface ResultMetrics {
+  payload: RankedPayload | undefined;
+  bm25Score: number | null;
+  bm25Rank: number | null;
+  similarity: number | null;
+  semanticRank: number | null;
+}
+
+function metricsFromRankedLists(
+  rankedLists: RankedFusionInput<RankedPayload>[],
+): Map<string, ResultMetrics> {
+  const metrics = new Map<string, ResultMetrics>();
   for (const list of rankedLists) {
-    for (const item of list) {
-      if (!fusionMap.has(item.key)) {
-        fusionMap.set(item.key, {
-          name: item.name,
-          kind: item.kind,
-          file: item.file,
-          line: item.line,
-          endLine: (item.endLine as number | null) ?? null,
-          role: (item.role as string | null) ?? null,
-          fileHash: (item.fileHash as string | null) ?? null,
-          rrfScore: 0,
-          bm25Score: null,
-          bm25Rank: null,
-          similarity: null,
-          semanticRank: null,
-        });
-      }
-      const entry = fusionMap.get(item.key)!;
-      entry.rrfScore += 1 / (k + item.rank);
-      if (item.source === 'bm25') {
-        if (entry.bm25Rank === null || item.rank < entry.bm25Rank) {
-          entry.bm25Score = (item as RankedItem & { bm25Score?: number }).bm25Score ?? null;
-          entry.bm25Rank = item.rank;
+    for (const result of list.results) {
+      const current = metrics.get(result.key) ?? {
+        payload: result.payload,
+        bm25Score: null,
+        bm25Rank: null,
+        similarity: null,
+        semanticRank: null,
+      };
+      if (current.payload === undefined) current.payload = result.payload;
+      if (result.payload?.source === 'bm25' || result.payload?.source === 'bm25_variant') {
+        if (current.bm25Rank === null || result.rank < current.bm25Rank) {
+          current.bm25Rank = result.rank;
+          current.bm25Score = result.payload.bm25Score ?? null;
         }
-      } else {
-        if (entry.semanticRank === null || item.rank < entry.semanticRank) {
-          entry.similarity = (item as RankedItem & { similarity?: number }).similarity ?? null;
-          entry.semanticRank = item.rank;
-        }
+      } else if (current.semanticRank === null || result.rank < current.semanticRank) {
+        current.semanticRank = result.rank;
+        current.similarity = result.payload?.similarity ?? null;
       }
+      metrics.set(result.key, current);
     }
   }
+  return metrics;
+}
 
-  return [...fusionMap.values()]
-    .sort((a, b) => b.rrfScore - a.rrfScore)
+function mapFusedResult(
+  score: number,
+  metrics: ResultMetrics | undefined,
+  explain: FusionExplain,
+  includeExplain: boolean,
+): HybridResult {
+  const payload = metrics?.payload;
+  return {
+    name: payload?.name ?? '',
+    kind: payload?.kind ?? '',
+    file: payload?.file ?? '',
+    line: payload?.line ?? 0,
+    endLine: payload?.endLine ?? null,
+    role: payload?.role ?? null,
+    fileHash: payload?.fileHash ?? null,
+    rrf: score,
+    bm25Score: metrics?.bm25Score ?? null,
+    bm25Rank: metrics?.bm25Rank ?? null,
+    similarity: metrics?.similarity ?? null,
+    semanticRank: metrics?.semanticRank ?? null,
+    ...(includeExplain ? { explain } : {}),
+  };
+}
+
+/** Weighted Reciprocal Rank Fusion: merge ranked lists into a single scored result set. */
+function fuseResults(
+  rankedLists: RankedFusionInput<RankedPayload>[],
+  config: CodegraphConfig['search'],
+  limit: number,
+  includeExplain: boolean,
+): HybridResult[] {
+  const fused = weightedRrfFuse(rankedLists, {
+    k: config.rrfK,
+    weights: weightsFromConfig(config),
+    topRankBonus: config.topRankBonus ?? 0,
+    topRankThreshold: config.topRankThreshold ?? 0,
+  });
+  const metrics = metricsFromRankedLists(rankedLists);
+
+  return fused
     .slice(0, limit)
-    .map((e) => ({
-      name: e.name,
-      kind: e.kind,
-      file: e.file,
-      line: e.line,
-      endLine: e.endLine,
-      role: e.role,
-      fileHash: e.fileHash,
-      rrf: e.rrfScore,
-      bm25Score: e.bm25Score,
-      bm25Rank: e.bm25Rank,
-      similarity: e.similarity,
-      semanticRank: e.semanticRank,
-    }));
+    .map((result) =>
+      mapFusedResult(result.score, metrics.get(result.key), result.explain, includeExplain),
+    );
 }
 
 export async function hybridSearchData(
@@ -193,8 +234,7 @@ export async function hybridSearchData(
   const config = opts.config || loadConfig();
   const searchCfg = config.search || ({} as CodegraphConfig['search']);
   const limit = opts.limit ?? searchCfg.topK ?? 15;
-  const k = opts.rrfK ?? searchCfg.rrfK ?? 60;
-  const topK = (opts.limit ?? searchCfg.topK ?? 15) * 5;
+  const topK = limit * 5;
 
   const checkDb = openReadonlyOrFail(customDbPath) as BetterSqlite3Database;
   const ftsAvailable = hasFtsIndex(checkDb);
@@ -203,7 +243,12 @@ export async function hybridSearchData(
 
   const queries = parseQueries(query);
   const rankedLists = await collectRankedLists(queries, customDbPath, opts, topK);
-  const results = fuseResults(rankedLists, k, limit);
+  const results = fuseResults(
+    rankedLists,
+    { ...searchCfg, rrfK: opts.rrfK ?? searchCfg.rrfK },
+    limit,
+    opts.explain ?? false,
+  );
 
   return { results };
 }

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -306,7 +306,10 @@ async function applyReranking(
   if (!rerankPort || !rerankEnabled) return { metaByKey: rerankMetaBykey, orderedKeys: null };
 
   const maxCandidates =
-    searchCfg.rerank?.maxCandidates ?? DEFAULTS.search.rerank?.maxCandidates ?? 20;
+    opts.rerankCandidates ??
+    searchCfg.rerank?.maxCandidates ??
+    DEFAULTS.search.rerank?.maxCandidates ??
+    20;
   const fusionWeight =
     searchCfg.rerank?.fusionWeight ?? DEFAULTS.search.rerank?.fusionWeight ?? 0.4;
   const rerankWeight =
@@ -389,7 +392,8 @@ export async function hybridSearchData(
   let rerankPort = (opts as SemanticSearchOpts & { rerankPort?: RerankPort }).rerankPort;
   let rerankMetaBykey = new Map<string, RerankResultMeta>();
   let orderedRerankKeys: string[] | null = null;
-  if (searchCfg.rerank?.enabled ?? false) {
+  const rerankEnabled = opts.rerank ?? searchCfg.rerank?.enabled ?? false;
+  if (rerankEnabled) {
     if (!rerankPort) {
       rerankPort = createDefaultRerankPort(resolveModelRoleUri(config, 'rerank')) ?? undefined;
     }

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -87,6 +87,7 @@ async function collectRankedLists(
         provider: opts.expansionProvider,
         timeoutMs: opts.expansionTimeoutMs,
         queryModes: opts.queryModes,
+        queryTextKind: opts.queryTextKind,
       },
       bm25Probe?.results ?? [],
     );

--- a/src/domain/search/search/keyword.ts
+++ b/src/domain/search/search/keyword.ts
@@ -15,6 +15,7 @@ export interface FtsSearchOpts {
 interface FtsRow {
   node_id: number;
   bm25_score: number;
+  content?: string | null;
   name: string;
   kind: string;
   file: string;
@@ -54,7 +55,7 @@ export function ftsSearchData(
     }
 
     let sql = `
-      SELECT f.rowid AS node_id, rank AS bm25_score,
+      SELECT f.rowid AS node_id, rank AS bm25_score, f.content AS content,
              n.name, n.kind, n.file, n.line, n.end_line, n.role
       FROM fts_index f
       JOIN nodes n ON f.rowid = n.id
@@ -92,6 +93,7 @@ export function ftsSearchData(
     const results = rows.slice(0, limit).map((row) => ({
       ...normalizeSymbol(row, db, hc),
       bm25Score: -row.bm25_score,
+      content: row.content ?? undefined,
     }));
 
     return { results };

--- a/src/domain/search/search/prepare.ts
+++ b/src/domain/search/search/prepare.ts
@@ -2,7 +2,7 @@ import { openReadonlyOrFail } from '../../../db/index.js';
 import { escapeLike } from '../../../db/query-builder.js';
 import { getEmbeddingCount, getEmbeddingMeta } from '../../../db/repository/embeddings.js';
 import type { BetterSqlite3Database } from '../../../types.js';
-import { MODELS } from '../models.js';
+import { MODELS, resolveModelKey } from '../models.js';
 import { applyFilters } from './filters.js';
 
 export interface PreparedSearch {
@@ -47,14 +47,10 @@ export function prepareSearch(
     const dimStr = getEmbeddingMeta(db, 'dim');
     const storedDim = dimStr ? parseInt(dimStr, 10) : null;
 
-    let modelKey = opts.model || null;
+    let modelKey = opts.model ? resolveModelKey(opts.model) : null;
     if (!modelKey && storedModel) {
-      for (const [key, config] of Object.entries(MODELS)) {
-        if (config.name === storedModel) {
-          modelKey = key;
-          break;
-        }
-      }
+      const resolvedStoredModel = resolveModelKey(storedModel);
+      modelKey = MODELS[resolvedStoredModel] ? resolvedStoredModel : storedModel;
     }
 
     const fp = opts.filePattern;

--- a/src/domain/search/search/prepare.ts
+++ b/src/domain/search/search/prepare.ts
@@ -2,6 +2,8 @@ import { openReadonlyOrFail } from '../../../db/index.js';
 import { escapeLike } from '../../../db/query-builder.js';
 import { getEmbeddingCount, getEmbeddingMeta } from '../../../db/repository/embeddings.js';
 import type { BetterSqlite3Database } from '../../../types.js';
+import type { EmbeddingMetadata } from '../metadata.js';
+import { readEmbeddingMetadata } from '../metadata.js';
 import { MODELS, resolveModelKey } from '../models.js';
 import { applyFilters } from './filters.js';
 
@@ -20,6 +22,7 @@ export interface PreparedSearch {
   }>;
   modelKey: string | null;
   storedDim: number | null;
+  storedMetadata: EmbeddingMetadata;
 }
 
 export interface PrepareSearchOpts {
@@ -43,9 +46,9 @@ export function prepareSearch(
       return null;
     }
 
-    const storedModel = getEmbeddingMeta(db, 'model') || null;
-    const dimStr = getEmbeddingMeta(db, 'dim');
-    const storedDim = dimStr ? parseInt(dimStr, 10) : null;
+    const storedMetadata = readEmbeddingMetadata(db);
+    const storedModel = storedMetadata.modelUri || getEmbeddingMeta(db, 'model') || null;
+    const storedDim = storedMetadata.dimension ?? null;
 
     let modelKey = opts.model ? resolveModelKey(opts.model) : null;
     if (!modelKey && storedModel) {
@@ -83,7 +86,7 @@ export function prepareSearch(
     let rows = db.prepare(sql).all(...params) as PreparedSearch['rows'];
     rows = applyFilters(rows, opts);
 
-    return { db, rows, modelKey, storedDim };
+    return { db, rows, modelKey, storedDim, storedMetadata };
   } catch (err) {
     db.close();
     throw err;

--- a/src/domain/search/search/prepare.ts
+++ b/src/domain/search/search/prepare.ts
@@ -13,6 +13,7 @@ export interface PreparedSearch {
     node_id: number;
     vector: Buffer;
     text_preview: string;
+    full_text?: string | null;
     name: string;
     kind: string;
     file: string;
@@ -56,11 +57,15 @@ export function prepareSearch(
       modelKey = MODELS[resolvedStoredModel] ? resolvedStoredModel : storedModel;
     }
 
+    const hasFullTextColumn = (
+      db.prepare("PRAGMA table_info('embeddings')").all() as Array<{ name: string }>
+    ).some((column) => column.name === 'full_text');
+
     const fp = opts.filePattern;
     const fpArr = Array.isArray(fp) ? fp : fp ? [fp] : [];
     const isGlob = fpArr.length > 0 && fpArr.some((p) => /[*?[\]]/.test(p));
     let sql = `
-    SELECT e.node_id, e.vector, e.text_preview, n.name, n.kind, n.file, n.line, n.end_line, n.role
+    SELECT e.node_id, e.vector, e.text_preview, ${hasFullTextColumn ? 'e.full_text' : 'NULL'} AS full_text, n.name, n.kind, n.file, n.line, n.end_line, n.role
     FROM embeddings e
     JOIN nodes n ON e.node_id = n.id
   `;

--- a/src/domain/search/search/rerank.ts
+++ b/src/domain/search/search/rerank.ts
@@ -28,6 +28,51 @@ export interface RerankPort {
   rerank(query: string, documents: string[]): Promise<RerankResult>;
 }
 
+/** Create a rerank port for safe built-in URI schemes. Local model URIs are intentionally unsupported here. */
+export function createDefaultRerankPort(uri: string | undefined): RerankPort | null {
+  if (!uri) return null;
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  return {
+    async rerank(query: string, documents: string[]): Promise<RerankResult> {
+      try {
+        const response = await fetch(url.toString(), {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ query, documents }),
+        });
+        if (!response.ok) {
+          return { ok: false, error: new Error(`HTTP ${response.status}`) };
+        }
+        const json = (await response.json()) as unknown;
+        const scores = Array.isArray(json)
+          ? json
+          : typeof json === 'object' &&
+              json !== null &&
+              Array.isArray((json as { scores?: unknown }).scores)
+            ? (json as { scores: unknown[] }).scores
+            : null;
+        if (!scores) return { ok: false, error: new Error('Invalid rerank response') };
+        const value = scores.flatMap((entry) => {
+          if (typeof entry !== 'object' || entry === null) return [];
+          const index = (entry as { index?: unknown }).index;
+          const score = (entry as { score?: unknown }).score;
+          return typeof index === 'number' && typeof score === 'number' ? [{ index, score }] : [];
+        });
+        return { ok: true, value };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err : new Error(String(err)) };
+      }
+    },
+  };
+}
+
 export interface RerankCandidate {
   /** Unique key for the candidate (name:file:line) */
   key: string;
@@ -39,6 +84,8 @@ export interface RerankCandidate {
   fusionScore: number;
   /** BM25 rank (null if candidate was not in BM25 results) */
   bm25Rank: number | null;
+  /** True only for the original/plain lexical BM25 rank-1 hit */
+  lexicalExactTopHit?: boolean;
   /** Best available text for reranking (full_text, preview, or metadata-derived) */
   text?: string;
 }
@@ -54,6 +101,10 @@ export interface RerankedCandidate extends RerankCandidate {
 export interface RerankExplain {
   /** True if this candidate was not reranked due to port failure */
   rerankFallback?: boolean;
+  /** Stable fallback code when reranking could not be applied */
+  fallbackCode?: 'disabled' | 'port_error';
+  /** Sanitized fallback message suitable for explain output */
+  fallbackMessage?: string;
   /** True if this candidate was protected as the lexical top hit */
   protectedLexicalHit?: boolean;
   /** Fusion weight used in blending */
@@ -129,7 +180,46 @@ function buildRerankQuery(query: string, intent?: string): string {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function isProtectedLexicalTopHit(candidate: RerankCandidate): boolean {
-  return candidate.bm25Rank === PROTECT_BM25_TOP_RANK;
+  return candidate.lexicalExactTopHit === true && candidate.bm25Rank === PROTECT_BM25_TOP_RANK;
+}
+
+function sanitizeFallbackMessage(message: string): string {
+  return message
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200);
+}
+
+function fallbackCandidates(
+  candidates: RerankCandidate[],
+  normalizeFusion: (score: number) => number,
+  fusionWeight: number,
+  rerankWeight: number,
+  fallbackCode: 'disabled' | 'port_error',
+  message?: string,
+): RerankedCandidate[] {
+  const fallbackMessage = message ? sanitizeFallbackMessage(message) : undefined;
+  return candidates
+    .map((c) => ({
+      ...c,
+      rerankScore: null,
+      blendedScore: normalizeFusion(c.fusionScore),
+      explain: {
+        rerankFallback: true,
+        fallbackCode,
+        ...(fallbackMessage ? { fallbackMessage } : {}),
+        fusionWeight,
+        rerankWeight,
+        normalizedFusion: normalizeFusion(c.fusionScore),
+        normalizedRerank: null,
+      },
+    }))
+    .sort((a, b) => {
+      const diff = b.blendedScore - a.blendedScore;
+      if (Math.abs(diff) > 1e-9) return diff;
+      return a.key.localeCompare(b.key);
+    });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -168,24 +258,13 @@ export async function rerankCandidates(
   // No reranker: return fusion-only ordering
   if (!rerankPort) {
     return {
-      candidates: candidates
-        .map((c) => ({
-          ...c,
-          rerankScore: null,
-          blendedScore: normalizeFusion(c.fusionScore),
-          explain: {
-            rerankFallback: true,
-            fusionWeight,
-            rerankWeight,
-            normalizedFusion: normalizeFusion(c.fusionScore),
-            normalizedRerank: null,
-          },
-        }))
-        .sort((a, b) => {
-          const diff = b.blendedScore - a.blendedScore;
-          if (Math.abs(diff) > 1e-9) return diff;
-          return a.key.localeCompare(b.key);
-        }),
+      candidates: fallbackCandidates(
+        candidates,
+        normalizeFusion,
+        fusionWeight,
+        rerankWeight,
+        'disabled',
+      ),
       reranked: false,
       fallbackReason: 'disabled',
     };
@@ -224,27 +303,17 @@ export async function rerankCandidates(
   let rerankResult: RerankResult;
   try {
     rerankResult = await rerankPort.rerank(rerankQuery, uniqueTexts);
-  } catch {
+  } catch (err) {
     // Port threw — fall back to fusion-only
     return {
-      candidates: candidates
-        .map((c) => ({
-          ...c,
-          rerankScore: null,
-          blendedScore: normalizeFusion(c.fusionScore),
-          explain: {
-            rerankFallback: true,
-            fusionWeight,
-            rerankWeight,
-            normalizedFusion: normalizeFusion(c.fusionScore),
-            normalizedRerank: null,
-          },
-        }))
-        .sort((a, b) => {
-          const diff = b.blendedScore - a.blendedScore;
-          if (Math.abs(diff) > 1e-9) return diff;
-          return a.key.localeCompare(b.key);
-        }),
+      candidates: fallbackCandidates(
+        candidates,
+        normalizeFusion,
+        fusionWeight,
+        rerankWeight,
+        'port_error',
+        err instanceof Error ? err.message : String(err),
+      ),
       reranked: false,
       fallbackReason: 'error',
     };
@@ -253,24 +322,14 @@ export async function rerankCandidates(
   // Port returned failure — fall back
   if (!rerankResult.ok || !rerankResult.value) {
     return {
-      candidates: candidates
-        .map((c) => ({
-          ...c,
-          rerankScore: null,
-          blendedScore: normalizeFusion(c.fusionScore),
-          explain: {
-            rerankFallback: true,
-            fusionWeight,
-            rerankWeight,
-            normalizedFusion: normalizeFusion(c.fusionScore),
-            normalizedRerank: null,
-          },
-        }))
-        .sort((a, b) => {
-          const diff = b.blendedScore - a.blendedScore;
-          if (Math.abs(diff) > 1e-9) return diff;
-          return a.key.localeCompare(b.key);
-        }),
+      candidates: fallbackCandidates(
+        candidates,
+        normalizeFusion,
+        fusionWeight,
+        rerankWeight,
+        'port_error',
+        rerankResult.error?.message ?? 'Rerank port returned an error',
+      ),
       reranked: false,
       fallbackReason: 'error',
     };

--- a/src/domain/search/search/rerank.ts
+++ b/src/domain/search/search/rerank.ts
@@ -86,8 +86,18 @@ export interface RerankCandidate {
   bm25Rank: number | null;
   /** True only for the original/plain lexical BM25 rank-1 hit */
   lexicalExactTopHit?: boolean;
-  /** Best available text for reranking (full_text, preview, or metadata-derived) */
+  /** Explicit text for reranking when callers have already selected the best source. */
   text?: string;
+  /** Full embedded symbol text, preferred over FTS content and previews. */
+  full_text?: string;
+  /** Full embedded symbol text, camelCase variant. */
+  fullText?: string;
+  /** Full FTS content, preferred over previews. */
+  content?: string;
+  /** Short embedded text preview. */
+  text_preview?: string;
+  /** Short embedded text preview, camelCase variant. */
+  textPreview?: string;
 }
 
 export interface RerankedCandidate extends RerankCandidate {
@@ -159,9 +169,16 @@ function normalizeScores(scores: number[]): (score: number) => number {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function candidateText(candidate: RerankCandidate): string {
-  if (candidate.text && candidate.text.trim().length > 0) {
-    return candidate.text;
-  }
+  const candidates = [
+    candidate.full_text,
+    candidate.fullText,
+    candidate.content,
+    candidate.text_preview,
+    candidate.textPreview,
+    candidate.text,
+  ];
+  const selected = candidates.find((text) => typeof text === 'string' && text.trim().length > 0);
+  if (selected) return selected;
   // Fallback: construct text from metadata
   return `${candidate.name} (${candidate.kind}) — ${candidate.file}:${candidate.line}`;
 }

--- a/src/domain/search/search/rerank.ts
+++ b/src/domain/search/search/rerank.ts
@@ -1,0 +1,363 @@
+/**
+ * Cross-encoder reranking with safe blending and lexical-hit protection.
+ *
+ * Uses a RerankPort to reorder top fusion candidates. When no port is supplied
+ * or the port fails, falls back cleanly to fusion-only ordering with actionable
+ * explain metadata.
+ *
+ * @module src/domain/search/search/rerank
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RerankScore {
+  index: number;
+  score: number;
+}
+
+export interface RerankResult<T = RerankScore[]> {
+  ok: boolean;
+  value?: T;
+  error?: Error;
+}
+
+/** Pluggable rerank port — inject a cross-encoder or mock implementation. */
+export interface RerankPort {
+  rerank(query: string, documents: string[]): Promise<RerankResult>;
+}
+
+export interface RerankCandidate {
+  /** Unique key for the candidate (name:file:line) */
+  key: string;
+  name: string;
+  kind: string;
+  file: string;
+  line: number;
+  /** RRF fusion score from hybrid search */
+  fusionScore: number;
+  /** BM25 rank (null if candidate was not in BM25 results) */
+  bm25Rank: number | null;
+  /** Best available text for reranking (full_text, preview, or metadata-derived) */
+  text?: string;
+}
+
+export interface RerankedCandidate extends RerankCandidate {
+  /** Cross-encoder score (normalized 0-1), null when not reranked */
+  rerankScore: number | null;
+  /** Final blended score combining fusion and rerank */
+  blendedScore: number;
+  explain?: RerankExplain;
+}
+
+export interface RerankExplain {
+  /** True if this candidate was not reranked due to port failure */
+  rerankFallback?: boolean;
+  /** True if this candidate was protected as the lexical top hit */
+  protectedLexicalHit?: boolean;
+  /** Fusion weight used in blending */
+  fusionWeight: number;
+  /** Rerank weight used in blending */
+  rerankWeight: number;
+  /** Normalized fusion score (0-1) */
+  normalizedFusion: number;
+  /** Normalized rerank score (0-1), null when not reranked */
+  normalizedRerank: number | null;
+}
+
+export interface RerankOptions {
+  /** Max candidates to send to the rerank port (default: from config, typically 20) */
+  maxCandidates?: number;
+  /** Weight for fusion scores in blending (default: 0.4) */
+  fusionWeight?: number;
+  /** Weight for rerank scores in blending (default: 0.6) */
+  rerankWeight?: number;
+  /** Optional intent context for intent-aware rerank queries */
+  intent?: string;
+}
+
+export interface RerankOutput {
+  candidates: RerankedCandidate[];
+  reranked: boolean;
+  fallbackReason: 'none' | 'disabled' | 'error';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PROTECT_BM25_TOP_RANK = 1;
+const REMAINING_CANDIDATE_PENALTY = 0.5;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Score normalization
+// ─────────────────────────────────────────────────────────────────────────────
+
+function normalizeScores(scores: number[]): (score: number) => number {
+  if (scores.length === 0) return () => 1;
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  const range = max - min;
+  if (range < 1e-9) return () => 1;
+  return (score: number) => Math.max(0, Math.min(1, (score - min) / range));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Text extraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+function candidateText(candidate: RerankCandidate): string {
+  if (candidate.text && candidate.text.trim().length > 0) {
+    return candidate.text;
+  }
+  // Fallback: construct text from metadata
+  return `${candidate.name} (${candidate.kind}) — ${candidate.file}:${candidate.line}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Intent-aware query building
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildRerankQuery(query: string, intent?: string): string {
+  if (!intent) return query;
+  return `${query}\nContext: ${intent}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lexical-hit protection
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isProtectedLexicalTopHit(candidate: RerankCandidate): boolean {
+  return candidate.bm25Rank === PROTECT_BM25_TOP_RANK;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main rerank function
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Rerank fusion candidates using a cross-encoder port.
+ *
+ * Falls back to fusion-only ordering when:
+ * - No rerank port is supplied (fallbackReason: 'disabled')
+ * - The rerank port returns an error or throws (fallbackReason: 'error')
+ *
+ * Protection: the original BM25 rank-1 hit is never demoted below position 1
+ * for exact lexical queries, even if the cross-encoder disagrees.
+ */
+export async function rerankCandidates(
+  rerankPort: RerankPort | null,
+  query: string,
+  candidates: RerankCandidate[],
+  options: RerankOptions = {},
+): Promise<RerankOutput> {
+  // Empty input → empty output
+  if (candidates.length === 0) {
+    return { candidates: [], reranked: false, fallbackReason: 'none' };
+  }
+
+  const fusionWeight = options.fusionWeight ?? 0.4;
+  const rerankWeight = options.rerankWeight ?? 0.6;
+  const maxCandidates = options.maxCandidates ?? 20;
+
+  // Normalize fusion scores across all candidates
+  const fusionScores = candidates.map((c) => c.fusionScore);
+  const normalizeFusion = normalizeScores(fusionScores);
+
+  // No reranker: return fusion-only ordering
+  if (!rerankPort) {
+    return {
+      candidates: candidates
+        .map((c) => ({
+          ...c,
+          rerankScore: null,
+          blendedScore: normalizeFusion(c.fusionScore),
+          explain: {
+            rerankFallback: true,
+            fusionWeight,
+            rerankWeight,
+            normalizedFusion: normalizeFusion(c.fusionScore),
+            normalizedRerank: null,
+          },
+        }))
+        .sort((a, b) => {
+          const diff = b.blendedScore - a.blendedScore;
+          if (Math.abs(diff) > 1e-9) return diff;
+          return a.key.localeCompare(b.key);
+        }),
+      reranked: false,
+      fallbackReason: 'disabled',
+    };
+  }
+
+  // Slice candidates for reranking
+  const toRerank = candidates.slice(0, maxCandidates);
+  const remaining = candidates.slice(maxCandidates);
+
+  // Extract texts and deduplicate
+  const texts = toRerank.map(candidateText);
+  const uniqueTexts: string[] = [];
+  const textToUniqueIndex = new Map<string, number>();
+  const originalIndexToUniqueIndex = new Map<number, number>();
+  const uniqueIndexToOriginalIndices = new Map<number, number[]>();
+
+  for (let i = 0; i < texts.length; i++) {
+    const text = texts[i]!;
+    const existing = textToUniqueIndex.get(text);
+    if (existing !== undefined) {
+      originalIndexToUniqueIndex.set(i, existing);
+      uniqueIndexToOriginalIndices.get(existing)!.push(i);
+    } else {
+      const uniqueIndex = uniqueTexts.length;
+      uniqueTexts.push(text);
+      textToUniqueIndex.set(text, uniqueIndex);
+      originalIndexToUniqueIndex.set(i, uniqueIndex);
+      uniqueIndexToOriginalIndices.set(uniqueIndex, [i]);
+    }
+  }
+
+  // Build intent-aware query
+  const rerankQuery = buildRerankQuery(query, options.intent);
+
+  // Call the rerank port
+  let rerankResult: RerankResult;
+  try {
+    rerankResult = await rerankPort.rerank(rerankQuery, uniqueTexts);
+  } catch {
+    // Port threw — fall back to fusion-only
+    return {
+      candidates: candidates
+        .map((c) => ({
+          ...c,
+          rerankScore: null,
+          blendedScore: normalizeFusion(c.fusionScore),
+          explain: {
+            rerankFallback: true,
+            fusionWeight,
+            rerankWeight,
+            normalizedFusion: normalizeFusion(c.fusionScore),
+            normalizedRerank: null,
+          },
+        }))
+        .sort((a, b) => {
+          const diff = b.blendedScore - a.blendedScore;
+          if (Math.abs(diff) > 1e-9) return diff;
+          return a.key.localeCompare(b.key);
+        }),
+      reranked: false,
+      fallbackReason: 'error',
+    };
+  }
+
+  // Port returned failure — fall back
+  if (!rerankResult.ok || !rerankResult.value) {
+    return {
+      candidates: candidates
+        .map((c) => ({
+          ...c,
+          rerankScore: null,
+          blendedScore: normalizeFusion(c.fusionScore),
+          explain: {
+            rerankFallback: true,
+            fusionWeight,
+            rerankWeight,
+            normalizedFusion: normalizeFusion(c.fusionScore),
+            normalizedRerank: null,
+          },
+        }))
+        .sort((a, b) => {
+          const diff = b.blendedScore - a.blendedScore;
+          if (Math.abs(diff) > 1e-9) return diff;
+          return a.key.localeCompare(b.key);
+        }),
+      reranked: false,
+      fallbackReason: 'error',
+    };
+  }
+
+  // Map rerank scores back to original candidate indices
+  const rerankScoresByUniqueIndex = new Map<number, number>();
+  for (const scoreEntry of rerankResult.value) {
+    rerankScoresByUniqueIndex.set(scoreEntry.index, scoreEntry.score);
+  }
+
+  const scoreByOriginalIndex = new Map<number, number>();
+  for (let i = 0; i < toRerank.length; i++) {
+    const uniqueIndex = originalIndexToUniqueIndex.get(i)!;
+    const score = rerankScoresByUniqueIndex.get(uniqueIndex);
+    if (score !== undefined) {
+      scoreByOriginalIndex.set(i, score);
+    }
+  }
+
+  // Normalize rerank scores
+  const allRerankScores = [...scoreByOriginalIndex.values()];
+  const normalizeRerank = normalizeScores(allRerankScores);
+
+  // Build reranked candidates with blended scores
+  const rerankedCandidates: RerankedCandidate[] = toRerank.map((c, i) => {
+    const rawRerank = scoreByOriginalIndex.get(i);
+    const normalizedRerank = rawRerank !== undefined ? normalizeRerank(rawRerank) : null;
+    const normalizedFusion = normalizeFusion(c.fusionScore);
+    const blendedScore =
+      normalizedRerank !== null
+        ? fusionWeight * normalizedFusion + rerankWeight * normalizedRerank
+        : normalizedFusion;
+
+    return {
+      ...c,
+      rerankScore: normalizedRerank,
+      blendedScore,
+      explain: {
+        fusionWeight,
+        rerankWeight,
+        normalizedFusion,
+        normalizedRerank,
+      },
+    };
+  });
+
+  // Add remaining candidates with penalty
+  const allCandidates: RerankedCandidate[] = [
+    ...rerankedCandidates,
+    ...remaining.map((c) => ({
+      ...c,
+      rerankScore: null as number | null,
+      blendedScore: Math.max(
+        0,
+        Math.min(1, normalizeFusion(c.fusionScore) * REMAINING_CANDIDATE_PENALTY),
+      ),
+      explain: {
+        fusionWeight,
+        rerankWeight,
+        normalizedFusion: normalizeFusion(c.fusionScore) * REMAINING_CANDIDATE_PENALTY,
+        normalizedRerank: null,
+      },
+    })),
+  ];
+
+  // Sort by blended score with deterministic tie-breaking
+  allCandidates.sort((a, b) => {
+    const diff = b.blendedScore - a.blendedScore;
+    if (Math.abs(diff) > 1e-9) return diff;
+    return a.key.localeCompare(b.key);
+  });
+
+  // Guardrail: protect strong lexical #1 hit from rerank-only demotion
+  const protectedTopHit = allCandidates.find(isProtectedLexicalTopHit);
+  if (protectedTopHit && allCandidates[0] !== protectedTopHit) {
+    // Move protected hit to position 0
+    const filtered = allCandidates.filter((c) => c !== protectedTopHit);
+    filtered.unshift({
+      ...protectedTopHit,
+      explain: {
+        ...protectedTopHit.explain!,
+        protectedLexicalHit: true,
+      },
+    });
+    return { candidates: filtered, reranked: true, fallbackReason: 'none' };
+  }
+
+  return { candidates: allCandidates, reranked: true, fallbackReason: 'none' };
+}

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -8,7 +8,7 @@ import { getEmbeddingBatchSize, getEmbeddingModelConfig } from '../models.js';
 import { embedWithRecovery } from '../ports.js';
 import { cosineSim } from '../stores/sqlite-blob.js';
 import { createVectorIndex } from '../vector-index.js';
-import type { ExpansionProvider, QueryModeInput } from './expansion.js';
+import type { ExpansionProvider, QueryModeInput, QueryTextKind } from './expansion.js';
 import { type PreparedSearch, prepareSearch } from './prepare.js';
 
 export interface SemanticSearchOpts {
@@ -24,6 +24,7 @@ export interface SemanticSearchOpts {
   expansionProvider?: ExpansionProvider;
   expansionTimeoutMs?: number;
   queryModes?: QueryModeInput[];
+  queryTextKind?: QueryTextKind;
 }
 
 interface SemanticResult {

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -8,6 +8,7 @@ import { getEmbeddingBatchSize, getEmbeddingModelConfig } from '../models.js';
 import { embedWithRecovery } from '../ports.js';
 import { cosineSim } from '../stores/sqlite-blob.js';
 import { createVectorIndex } from '../vector-index.js';
+import type { ExpansionProvider } from './expansion.js';
 import { type PreparedSearch, prepareSearch } from './prepare.js';
 
 export interface SemanticSearchOpts {
@@ -19,6 +20,9 @@ export interface SemanticSearchOpts {
   filePattern?: string | string[];
   noTests?: boolean;
   rrfK?: number;
+  expand?: boolean;
+  expansionProvider?: ExpansionProvider;
+  expansionTimeoutMs?: number;
 }
 
 interface SemanticResult {

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -2,7 +2,9 @@ import { loadConfig } from '../../../infrastructure/config.js';
 import { warn } from '../../../infrastructure/logger.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
 import { normalizeSymbol } from '../../queries.js';
-import { embed } from '../models.js';
+import { createEmbeddingPort } from '../embedding-factory.js';
+import { getEmbeddingModelConfig } from '../models.js';
+import { embedWithRecovery } from '../ports.js';
 import { cosineSim } from '../stores/sqlite-blob.js';
 import { prepareSearch } from './prepare.js';
 
@@ -45,10 +47,12 @@ export async function searchData(
   const { db, rows, modelKey, storedDim } = prepared;
 
   try {
-    const {
-      vectors: [queryVec],
-      dim,
-    } = await embed([query], modelKey ?? undefined);
+    const activeModel = modelKey ?? undefined;
+    const queryPort = await createEmbeddingPort(activeModel ?? getEmbeddingModelConfig().name, {
+      inputType: 'query',
+    });
+    const [queryVec] = await embedWithRecovery(queryPort, [query]);
+    const dim = queryVec?.length ?? getEmbeddingModelConfig(activeModel).dim;
 
     if (storedDim && dim !== storedDim) {
       console.log(
@@ -107,7 +111,12 @@ export async function multiSearchData(
   const { db, rows, modelKey, storedDim } = prepared;
 
   try {
-    const { vectors: queryVecs, dim } = await embed(queries, modelKey ?? undefined);
+    const activeModel = modelKey ?? undefined;
+    const queryPort = await createEmbeddingPort(activeModel ?? getEmbeddingModelConfig().name, {
+      inputType: 'query',
+    });
+    const queryVecs = await embedWithRecovery(queryPort, queries);
+    const dim = queryVecs[0]?.length ?? getEmbeddingModelConfig(activeModel).dim;
 
     const SIMILARITY_WARN_THRESHOLD = searchCfg.similarityWarnThreshold ?? 0.85;
     for (let i = 0; i < queryVecs.length; i++) {

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -26,6 +26,10 @@ export interface SemanticSearchOpts {
   queryModes?: QueryModeInput[];
   queryTextKind?: QueryTextKind;
   explain?: boolean;
+  /** Enable/disable hybrid reranking for this request. Undefined uses config. */
+  rerank?: boolean;
+  /** Override the number of fused candidates eligible for reranking. */
+  rerankCandidates?: number;
   /** Injected rerank port for cross-encoder reranking (default-off unless provided + config enabled) */
   rerankPort?: import('./rerank.js').RerankPort;
 }

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -8,7 +8,7 @@ import { getEmbeddingBatchSize, getEmbeddingModelConfig } from '../models.js';
 import { embedWithRecovery } from '../ports.js';
 import { cosineSim } from '../stores/sqlite-blob.js';
 import { createVectorIndex } from '../vector-index.js';
-import type { ExpansionProvider } from './expansion.js';
+import type { ExpansionProvider, QueryModeInput } from './expansion.js';
 import { type PreparedSearch, prepareSearch } from './prepare.js';
 
 export interface SemanticSearchOpts {
@@ -23,6 +23,7 @@ export interface SemanticSearchOpts {
   expand?: boolean;
   expansionProvider?: ExpansionProvider;
   expansionTimeoutMs?: number;
+  queryModes?: QueryModeInput[];
 }
 
 interface SemanticResult {

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -55,6 +55,8 @@ function bruteForceSemanticResults(
       results.push({
         ...normalizeSymbol(row, db as BetterSqlite3Database, hc),
         similarity: sim,
+        text_preview: row.text_preview,
+        full_text: row.full_text,
       });
     }
   }
@@ -90,6 +92,8 @@ function tryAcceleratedSemanticResults(
     results.push({
       ...normalizeSymbol(row, db as BetterSqlite3Database, hc),
       similarity: hit.similarity,
+      text_preview: row.text_preview,
+      full_text: row.full_text,
     });
   }
   return results;

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -54,13 +54,19 @@ function bruteForceSemanticResults(
   return results;
 }
 
+function hasSemanticFilters(opts: SemanticSearchOpts): boolean {
+  return Boolean(opts.kind || opts.filePattern || opts.noTests);
+}
+
 function tryAcceleratedSemanticResults(
   prepared: PreparedSearch,
   queryVec: Float32Array,
   activeMetadata: ReturnType<typeof expectedEmbeddingMetadata>,
   limit: number,
   minScore: number,
+  filtersActive: boolean,
 ): SemanticResult[] | null {
+  if (filtersActive) return null;
   const { db, rows } = prepared;
   const vectorIndex = createVectorIndex(db, activeMetadata, { mode: 'search' });
   const accelerated = vectorIndex.searchNearest(queryVec, limit, { minScore });
@@ -136,6 +142,7 @@ export async function searchData(
           activeMetadata,
           limit,
           minScore,
+          hasSemanticFilters(opts),
         )
       : null;
     const results =

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -25,6 +25,7 @@ export interface SemanticSearchOpts {
   expansionTimeoutMs?: number;
   queryModes?: QueryModeInput[];
   queryTextKind?: QueryTextKind;
+  explain?: boolean;
 }
 
 interface SemanticResult {

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -3,7 +3,7 @@ import { warn } from '../../../infrastructure/logger.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
 import { normalizeSymbol } from '../../queries.js';
 import { createEmbeddingPort } from '../embedding-factory.js';
-import { getEmbeddingModelConfig } from '../models.js';
+import { getEmbeddingBatchSize, getEmbeddingModelConfig } from '../models.js';
 import { embedWithRecovery } from '../ports.js';
 import { cosineSim } from '../stores/sqlite-blob.js';
 import { prepareSearch } from './prepare.js';
@@ -115,7 +115,9 @@ export async function multiSearchData(
     const queryPort = await createEmbeddingPort(activeModel ?? getEmbeddingModelConfig().name, {
       inputType: 'query',
     });
-    const queryVecs = await embedWithRecovery(queryPort, queries);
+    const queryVecs = await embedWithRecovery(queryPort, queries, {
+      batchSize: getEmbeddingBatchSize(activeModel),
+    });
     const dim = queryVecs[0]?.length ?? getEmbeddingModelConfig(activeModel).dim;
 
     const SIMILARITY_WARN_THRESHOLD = searchCfg.similarityWarnThreshold ?? 0.85;

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -7,7 +7,8 @@ import { expectedEmbeddingMetadata, warnIfEmbeddingMetadataStale } from '../meta
 import { getEmbeddingBatchSize, getEmbeddingModelConfig } from '../models.js';
 import { embedWithRecovery } from '../ports.js';
 import { cosineSim } from '../stores/sqlite-blob.js';
-import { prepareSearch } from './prepare.js';
+import { createVectorIndex } from '../vector-index.js';
+import { type PreparedSearch, prepareSearch } from './prepare.js';
 
 export interface SemanticSearchOpts {
   config?: CodegraphConfig;
@@ -27,6 +28,56 @@ interface SemanticResult {
   line: number;
   similarity: number;
   [key: string]: unknown;
+}
+
+function bruteForceSemanticResults(
+  prepared: PreparedSearch,
+  queryVec: Float32Array,
+  minScore: number,
+): SemanticResult[] {
+  const { db, rows } = prepared;
+  const hc = new Map<string, string>();
+  const results: SemanticResult[] = [];
+  for (const row of rows) {
+    const vec = new Float32Array(new Uint8Array(row.vector as unknown as ArrayBuffer).buffer);
+    const sim = cosineSim(queryVec, vec);
+
+    if (sim >= minScore) {
+      results.push({
+        ...normalizeSymbol(row, db as BetterSqlite3Database, hc),
+        similarity: sim,
+      });
+    }
+  }
+
+  results.sort((a, b) => b.similarity - a.similarity);
+  return results;
+}
+
+function tryAcceleratedSemanticResults(
+  prepared: PreparedSearch,
+  queryVec: Float32Array,
+  activeMetadata: ReturnType<typeof expectedEmbeddingMetadata>,
+  limit: number,
+  minScore: number,
+): SemanticResult[] | null {
+  const { db, rows } = prepared;
+  const vectorIndex = createVectorIndex(db, activeMetadata, { mode: 'search' });
+  const accelerated = vectorIndex.searchNearest(queryVec, limit, { minScore });
+  if (!accelerated.ok) return null;
+
+  const byNodeId = new Map(rows.map((row) => [row.node_id, row]));
+  const hc = new Map<string, string>();
+  const results: SemanticResult[] = [];
+  for (const hit of accelerated.value) {
+    const row = byNodeId.get(hit.nodeId);
+    if (!row) continue;
+    results.push({
+      ...normalizeSymbol(row, db as BetterSqlite3Database, hc),
+      similarity: hit.similarity,
+    });
+  }
+  return results;
 }
 
 export interface SearchDataResult {
@@ -58,6 +109,11 @@ export async function searchData(
       }),
       { modelHint: activeModel ?? activeConfig.name, command: 'search' },
     );
+    const expectedMetadata = expectedEmbeddingMetadata({
+      modelUri: activeConfig.name,
+      dimension: activeConfig.dim || undefined,
+      strategy: storedMetadata.strategy,
+    });
     const queryPort = await createEmbeddingPort(activeModel ?? getEmbeddingModelConfig().name, {
       inputType: 'query',
     });
@@ -72,21 +128,23 @@ export async function searchData(
       return null;
     }
 
-    const hc = new Map<string, string>();
-    const results: SemanticResult[] = [];
-    for (const row of rows) {
-      const vec = new Float32Array(new Uint8Array(row.vector as unknown as ArrayBuffer).buffer);
-      const sim = cosineSim(queryVec!, vec);
-
-      if (sim >= minScore) {
-        results.push({
-          ...normalizeSymbol(row, db as BetterSqlite3Database, hc),
-          similarity: sim,
-        });
-      }
-    }
-
-    results.sort((a, b) => b.similarity - a.similarity);
+    const activeMetadata = { ...expectedMetadata, dimension: dim };
+    const accelerated = queryVec
+      ? tryAcceleratedSemanticResults(
+          { db, rows, modelKey, storedDim, storedMetadata },
+          queryVec,
+          activeMetadata,
+          limit,
+          minScore,
+        )
+      : null;
+    const results =
+      accelerated ??
+      bruteForceSemanticResults(
+        { db, rows, modelKey, storedDim, storedMetadata },
+        queryVec!,
+        minScore,
+      );
     return { results: results.slice(0, limit) };
   } finally {
     db.close();

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -30,7 +30,7 @@ export interface SemanticSearchOpts {
   rerank?: boolean;
   /** Override the number of fused candidates eligible for reranking. */
   rerankCandidates?: number;
-  /** Injected rerank port for cross-encoder reranking (default-off unless provided + config enabled) */
+  /** Optional injected rerank port for tests/custom cross-encoder reranking. */
   rerankPort?: import('./rerank.js').RerankPort;
 }
 

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -26,6 +26,8 @@ export interface SemanticSearchOpts {
   queryModes?: QueryModeInput[];
   queryTextKind?: QueryTextKind;
   explain?: boolean;
+  /** Injected rerank port for cross-encoder reranking (default-off unless provided + config enabled) */
+  rerankPort?: import('./rerank.js').RerankPort;
 }
 
 interface SemanticResult {

--- a/src/domain/search/search/semantic.ts
+++ b/src/domain/search/search/semantic.ts
@@ -3,6 +3,7 @@ import { warn } from '../../../infrastructure/logger.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
 import { normalizeSymbol } from '../../queries.js';
 import { createEmbeddingPort } from '../embedding-factory.js';
+import { expectedEmbeddingMetadata, warnIfEmbeddingMetadataStale } from '../metadata.js';
 import { getEmbeddingBatchSize, getEmbeddingModelConfig } from '../models.js';
 import { embedWithRecovery } from '../ports.js';
 import { cosineSim } from '../stores/sqlite-blob.js';
@@ -44,10 +45,19 @@ export async function searchData(
 
   const prepared = prepareSearch(customDbPath, opts);
   if (!prepared) return null;
-  const { db, rows, modelKey, storedDim } = prepared;
+  const { db, rows, modelKey, storedDim, storedMetadata } = prepared;
 
   try {
     const activeModel = modelKey ?? undefined;
+    const activeConfig = getEmbeddingModelConfig(activeModel);
+    warnIfEmbeddingMetadataStale(
+      storedMetadata,
+      expectedEmbeddingMetadata({
+        modelUri: activeConfig.name,
+        dimension: activeConfig.dim || undefined,
+      }),
+      { modelHint: activeModel ?? activeConfig.name, command: 'search' },
+    );
     const queryPort = await createEmbeddingPort(activeModel ?? getEmbeddingModelConfig().name, {
       inputType: 'query',
     });
@@ -108,10 +118,19 @@ export async function multiSearchData(
 
   const prepared = prepareSearch(customDbPath, opts);
   if (!prepared) return null;
-  const { db, rows, modelKey, storedDim } = prepared;
+  const { db, rows, modelKey, storedDim, storedMetadata } = prepared;
 
   try {
     const activeModel = modelKey ?? undefined;
+    const activeConfig = getEmbeddingModelConfig(activeModel);
+    warnIfEmbeddingMetadataStale(
+      storedMetadata,
+      expectedEmbeddingMetadata({
+        modelUri: activeConfig.name,
+        dimension: activeConfig.dim || undefined,
+      }),
+      { modelHint: activeModel ?? activeConfig.name, command: 'search' },
+    );
     const queryPort = await createEmbeddingPort(activeModel ?? getEmbeddingModelConfig().name, {
       inputType: 'query',
     });

--- a/src/domain/search/vector-index.ts
+++ b/src/domain/search/vector-index.ts
@@ -114,7 +114,37 @@ function ensureStorageTable(db: BetterSqlite3Database): void {
       FOREIGN KEY(node_id) REFERENCES nodes(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_embedding_vectors_model ON embedding_vectors(metadata_key, node_id);
+    CREATE TABLE IF NOT EXISTS embedding_vector_index_meta (
+      metadata_key TEXT PRIMARY KEY,
+      healthy INTEGER NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
   `);
+}
+
+function hasVectorIndexMetaTable(db: BetterSqlite3Database): boolean {
+  const row = db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'embedding_vector_index_meta'",
+    )
+    .get();
+  return Boolean(row);
+}
+
+function readVecDirty(db: BetterSqlite3Database, metadataKey: string): boolean {
+  if (!hasVectorIndexMetaTable(db)) return false;
+  const row = db
+    .prepare('SELECT healthy FROM embedding_vector_index_meta WHERE metadata_key = ?')
+    .get(metadataKey) as { healthy: number } | undefined;
+  return row ? row.healthy !== 1 : false;
+}
+
+function writeVecDirty(db: BetterSqlite3Database, metadataKey: string, dirty: boolean): void {
+  ensureStorageTable(db);
+  db.prepare(
+    `INSERT OR REPLACE INTO embedding_vector_index_meta (metadata_key, healthy, updated_at)
+     VALUES (?, ?, CURRENT_TIMESTAMP)`,
+  ).run(metadataKey, dirty ? 0 : 1);
 }
 
 function readRows(db: BetterSqlite3Database, metadataKey: string, modelUri: string): VectorRow[] {
@@ -215,6 +245,7 @@ export function createVectorIndex(
 
   try {
     if (options.mode !== 'search') ensureStorageTable(db);
+    vecDirty = readVecDirty(db, metadataKey);
   } catch (error) {
     loadError = error instanceof Error ? error.message : String(error);
   }
@@ -251,8 +282,27 @@ export function createVectorIndex(
     },
     set vecDirty(value: boolean) {
       vecDirty = value;
+      try {
+        writeVecDirty(db, metadataKey, value);
+      } catch (error) {
+        warn(
+          `Vector acceleration health metadata write failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     },
     upsertVectors(rows) {
+      const mismatch = rows.find(
+        (row) =>
+          row.metadataKey !== metadataKey ||
+          row.model !== metadata.modelUri ||
+          row.embedding.length !== metadata.dimension,
+      );
+      if (mismatch) {
+        return err(
+          'VECTOR_METADATA_MISMATCH',
+          `Vector row metadata/dimension does not match active index metadata for node ${mismatch.nodeId}`,
+        );
+      }
       try {
         ensureStorageTable(db);
         const insert = db.prepare(
@@ -286,7 +336,7 @@ export function createVectorIndex(
             rows.filter((row) => row.metadataKey === metadataKey),
           );
         } catch (error) {
-          vecDirty = true;
+          this.vecDirty = true;
           warn(
             `Vector acceleration write failed; falling back to brute-force search until sync succeeds: ${error instanceof Error ? error.message : String(error)}`,
           );
@@ -314,7 +364,7 @@ export function createVectorIndex(
         try {
           driver.delete(db, tableName, nodeIds);
         } catch {
-          vecDirty = true;
+          this.vecDirty = true;
         }
       }
       return ok(undefined);
@@ -324,6 +374,12 @@ export function createVectorIndex(
         return err(
           'VECTOR_SEARCH_UNAVAILABLE',
           `Vector acceleration is unavailable. ${loadError ? `Reason: ${loadError}. ` : ''}${SQLITE_VEC_GUIDANCE}`,
+        );
+      }
+      if (vecDirty) {
+        return err(
+          'VECTOR_INDEX_DIRTY',
+          'Vector acceleration index is dirty; falling back to brute-force semantic search until sync succeeds.',
         );
       }
       try {
@@ -349,10 +405,10 @@ export function createVectorIndex(
       if (!searchAvailable) return ok(undefined);
       try {
         driver.rebuild(db, tableName, storageRows());
-        vecDirty = false;
+        this.vecDirty = false;
         return ok(undefined);
       } catch (error) {
-        vecDirty = true;
+        this.vecDirty = true;
         return err(
           'VECTOR_REBUILD_FAILED',
           `Vector acceleration rebuild failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -363,10 +419,10 @@ export function createVectorIndex(
       if (!searchAvailable) return ok({ added: 0, removed: 0 });
       try {
         const result = driver.sync(db, tableName, storageRows());
-        vecDirty = false;
+        this.vecDirty = false;
         return ok(result);
       } catch (error) {
-        vecDirty = true;
+        this.vecDirty = true;
         return err(
           'VECTOR_SYNC_FAILED',
           `Vector acceleration sync failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/domain/search/vector-index.ts
+++ b/src/domain/search/vector-index.ts
@@ -1,0 +1,377 @@
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { warn } from '../../infrastructure/logger.js';
+import type { BetterSqlite3Database } from '../../types.js';
+import type { ActiveEmbeddingMetadata } from './metadata.js';
+
+export type StoreResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: { code: string; message: string } };
+
+function ok<T>(value: T): StoreResult<T> {
+  return { ok: true, value };
+}
+
+function err<T>(code: string, message: string): StoreResult<T> {
+  return { ok: false, error: { code, message } };
+}
+
+export interface VectorRow {
+  nodeId: number;
+  model: string;
+  metadataKey: string;
+  embedding: Float32Array;
+}
+
+export interface VectorSearchResult {
+  nodeId: number;
+  distance: number;
+  similarity: number;
+}
+
+export interface VectorAccelerationDriver {
+  load(db: BetterSqlite3Database): void;
+  createTable(db: BetterSqlite3Database, tableName: string, dimensions: number): void;
+  upsert(db: BetterSqlite3Database, tableName: string, rows: VectorRow[]): void;
+  delete(db: BetterSqlite3Database, tableName: string, nodeIds: number[]): void;
+  search(
+    db: BetterSqlite3Database,
+    tableName: string,
+    embedding: Float32Array,
+    k: number,
+  ): Array<{ nodeId: number; distance: number }>;
+  rebuild(db: BetterSqlite3Database, tableName: string, rows: VectorRow[]): void;
+  sync(
+    db: BetterSqlite3Database,
+    tableName: string,
+    rows: VectorRow[],
+  ): { added: number; removed: number };
+}
+
+export interface VectorIndex {
+  readonly searchAvailable: boolean;
+  readonly loadError?: string;
+  readonly guidance?: string;
+  readonly tableName: string;
+  readonly metadataKey: string;
+  vecDirty: boolean;
+  upsertVectors(rows: VectorRow[]): StoreResult<void>;
+  deleteVectors(nodeIds: number[]): StoreResult<void>;
+  searchNearest(
+    embedding: Float32Array,
+    k: number,
+    options?: { minScore?: number },
+  ): StoreResult<VectorSearchResult[]>;
+  rebuildVecIndex(): StoreResult<void>;
+  syncVecIndex(): StoreResult<{ added: number; removed: number }>;
+}
+
+export interface CreateVectorIndexOptions {
+  driver?: VectorAccelerationDriver;
+  mode?: 'storage' | 'search';
+}
+
+const SQLITE_VEC_GUIDANCE =
+  'Install sqlite-vec support to enable accelerated vector search; brute-force semantic search remains available.';
+
+export function encodeEmbedding(f32: Float32Array): Buffer {
+  return Buffer.from(f32.buffer.slice(f32.byteOffset, f32.byteOffset + f32.byteLength));
+}
+
+export function decodeEmbedding(blob: Uint8Array): Float32Array {
+  if (blob.byteLength % 4 !== 0) {
+    throw new Error(`Invalid embedding blob: length ${blob.byteLength} is not aligned to 4 bytes`);
+  }
+  const copy = new Uint8Array(blob);
+  return new Float32Array(copy.buffer, copy.byteOffset, copy.byteLength / 4);
+}
+
+export function vectorStorageKey(metadata: ActiveEmbeddingMetadata): string {
+  return [
+    metadata.modelUri,
+    metadata.dimension ?? '',
+    metadata.strategy ?? '',
+    metadata.compatibilityProfile,
+    metadata.formatterVersion,
+  ].join('\u001f');
+}
+
+export function vectorTableName(metadata: ActiveEmbeddingMetadata): string {
+  const hash = createHash('sha256').update(vectorStorageKey(metadata)).digest('hex').slice(0, 16);
+  return `vec_embeddings_${hash}`;
+}
+
+function ensureStorageTable(db: BetterSqlite3Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS embedding_vectors (
+      node_id INTEGER NOT NULL,
+      model_uri TEXT NOT NULL,
+      metadata_key TEXT NOT NULL,
+      dimension INTEGER NOT NULL,
+      vector BLOB NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (node_id, metadata_key),
+      FOREIGN KEY(node_id) REFERENCES nodes(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_embedding_vectors_model ON embedding_vectors(metadata_key, node_id);
+  `);
+}
+
+function readRows(db: BetterSqlite3Database, metadataKey: string, modelUri: string): VectorRow[] {
+  const rows = db
+    .prepare(
+      'SELECT node_id, vector FROM embedding_vectors WHERE metadata_key = ? AND model_uri = ? ORDER BY node_id',
+    )
+    .all(metadataKey, modelUri) as Array<{ node_id: number; vector: Buffer }>;
+  return rows.map((row) => ({
+    nodeId: row.node_id,
+    model: modelUri,
+    metadataKey,
+    embedding: decodeEmbedding(row.vector),
+  }));
+}
+
+export const sqliteVecDriver: VectorAccelerationDriver = {
+  load(db) {
+    const require = createRequire(import.meta.url);
+    const sqliteVec = require('sqlite-vec') as {
+      load?: (db: BetterSqlite3Database) => void;
+      loadablePath?: string;
+      default?: { load?: (db: BetterSqlite3Database) => void; loadablePath?: string };
+    };
+    const load = sqliteVec.load ?? sqliteVec.default?.load;
+    if (load) {
+      load(db);
+      return;
+    }
+    const loadablePath = sqliteVec.loadablePath ?? sqliteVec.default?.loadablePath;
+    const loadExtension = (db as unknown as { loadExtension?: (path: string) => void })
+      .loadExtension;
+    if (loadablePath && loadExtension) {
+      loadExtension.call(db, loadablePath);
+      return;
+    }
+    throw new Error('sqlite-vec package did not expose a compatible loader');
+  },
+  createTable(db, tableName, dimensions) {
+    db.exec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS ${tableName} USING vec0(node_id INTEGER PRIMARY KEY, embedding FLOAT[${dimensions}] distance_metric=cosine);`,
+    );
+  },
+  upsert(db, tableName, rows) {
+    const del = db.prepare(`DELETE FROM ${tableName} WHERE node_id = ?`);
+    const insert = db.prepare(`INSERT INTO ${tableName} (node_id, embedding) VALUES (?, ?)`);
+    const tx = db.transaction(() => {
+      for (const row of rows) {
+        del.run(row.nodeId);
+        insert.run(row.nodeId, encodeEmbedding(row.embedding));
+      }
+    });
+    tx();
+  },
+  delete(db, tableName, nodeIds) {
+    const del = db.prepare(`DELETE FROM ${tableName} WHERE node_id = ?`);
+    const tx = db.transaction(() => {
+      for (const nodeId of nodeIds) del.run(nodeId);
+    });
+    tx();
+  },
+  search(db, tableName, embedding, k) {
+    return db
+      .prepare(
+        `SELECT node_id as nodeId, distance FROM ${tableName} WHERE embedding MATCH ? AND k = ?`,
+      )
+      .all(encodeEmbedding(embedding), k) as Array<{ nodeId: number; distance: number }>;
+  },
+  rebuild(db, tableName, rows) {
+    db.exec(`DELETE FROM ${tableName}`);
+    this.upsert(db, tableName, rows);
+  },
+  sync(db, tableName, rows) {
+    this.rebuild(db, tableName, rows);
+    return { added: rows.length, removed: 0 };
+  },
+};
+
+let testVectorAccelerationDriver: VectorAccelerationDriver | undefined;
+
+export function setVectorAccelerationDriverForTests(
+  driver: VectorAccelerationDriver | undefined,
+): void {
+  testVectorAccelerationDriver = driver;
+}
+
+export function createVectorIndex(
+  db: BetterSqlite3Database,
+  metadata: ActiveEmbeddingMetadata,
+  options: CreateVectorIndexOptions = {},
+): VectorIndex {
+  const metadataKey = vectorStorageKey(metadata);
+  const tableName = vectorTableName(metadata);
+  const driver = options.driver ?? testVectorAccelerationDriver ?? sqliteVecDriver;
+  let searchAvailable = false;
+  let loadError: string | undefined;
+  let vecDirty = false;
+
+  try {
+    if (options.mode !== 'search') ensureStorageTable(db);
+  } catch (error) {
+    loadError = error instanceof Error ? error.message : String(error);
+  }
+
+  try {
+    driver.load(db);
+    if (options.mode !== 'search') {
+      driver.createTable(db, tableName, metadata.dimension ?? 0);
+    }
+    searchAvailable = true;
+  } catch (error) {
+    loadError = error instanceof Error ? error.message : String(error);
+    searchAvailable = false;
+  }
+
+  function storageRows(): VectorRow[] {
+    return readRows(db, metadataKey, metadata.modelUri);
+  }
+
+  return {
+    get searchAvailable() {
+      return searchAvailable;
+    },
+    get loadError() {
+      return loadError;
+    },
+    get guidance() {
+      return searchAvailable ? undefined : SQLITE_VEC_GUIDANCE;
+    },
+    tableName,
+    metadataKey,
+    get vecDirty() {
+      return vecDirty;
+    },
+    set vecDirty(value: boolean) {
+      vecDirty = value;
+    },
+    upsertVectors(rows) {
+      try {
+        ensureStorageTable(db);
+        const insert = db.prepare(
+          `INSERT OR REPLACE INTO embedding_vectors (node_id, model_uri, metadata_key, dimension, vector, updated_at)
+           VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+        );
+        const tx = db.transaction(() => {
+          for (const row of rows) {
+            insert.run(
+              row.nodeId,
+              row.model,
+              row.metadataKey,
+              row.embedding.length,
+              encodeEmbedding(row.embedding),
+            );
+          }
+        });
+        tx();
+      } catch (error) {
+        return err(
+          'VECTOR_WRITE_FAILED',
+          `Vector write failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      if (searchAvailable) {
+        try {
+          driver.upsert(
+            db,
+            tableName,
+            rows.filter((row) => row.metadataKey === metadataKey),
+          );
+        } catch (error) {
+          vecDirty = true;
+          warn(
+            `Vector acceleration write failed; falling back to brute-force search until sync succeeds: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+      return ok(undefined);
+    },
+    deleteVectors(nodeIds) {
+      try {
+        ensureStorageTable(db);
+        const del = db.prepare(
+          'DELETE FROM embedding_vectors WHERE node_id = ? AND metadata_key = ?',
+        );
+        const tx = db.transaction(() => {
+          for (const nodeId of nodeIds) del.run(nodeId, metadataKey);
+        });
+        tx();
+      } catch (error) {
+        return err(
+          'VECTOR_DELETE_FAILED',
+          `Vector delete failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      if (searchAvailable) {
+        try {
+          driver.delete(db, tableName, nodeIds);
+        } catch {
+          vecDirty = true;
+        }
+      }
+      return ok(undefined);
+    },
+    searchNearest(embedding, k, searchOptions) {
+      if (!searchAvailable) {
+        return err(
+          'VECTOR_SEARCH_UNAVAILABLE',
+          `Vector acceleration is unavailable. ${loadError ? `Reason: ${loadError}. ` : ''}${SQLITE_VEC_GUIDANCE}`,
+        );
+      }
+      try {
+        const rows = driver.search(db, tableName, embedding, k);
+        const minScore = searchOptions?.minScore;
+        return ok(
+          rows
+            .map((row) => ({
+              nodeId: row.nodeId,
+              distance: row.distance,
+              similarity: 1 - row.distance,
+            }))
+            .filter((row) => minScore === undefined || row.similarity >= minScore),
+        );
+      } catch (error) {
+        return err(
+          'VECTOR_SEARCH_FAILED',
+          `Vector acceleration search failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    },
+    rebuildVecIndex() {
+      if (!searchAvailable) return ok(undefined);
+      try {
+        driver.rebuild(db, tableName, storageRows());
+        vecDirty = false;
+        return ok(undefined);
+      } catch (error) {
+        vecDirty = true;
+        return err(
+          'VECTOR_REBUILD_FAILED',
+          `Vector acceleration rebuild failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    },
+    syncVecIndex() {
+      if (!searchAvailable) return ok({ added: 0, removed: 0 });
+      try {
+        const result = driver.sync(db, tableName, storageRows());
+        vecDirty = false;
+        return ok(result);
+      } catch (error) {
+        vecDirty = true;
+        return err(
+          'VECTOR_SYNC_FAILED',
+          `Vector acceleration sync failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    },
+  };
+}

--- a/src/domain/search/vector-index.ts
+++ b/src/domain/search/vector-index.ts
@@ -303,6 +303,8 @@ export function createVectorIndex(
           `Vector row metadata/dimension does not match active index metadata for node ${mismatch.nodeId}`,
         );
       }
+      const wasDirty = vecDirty;
+      this.vecDirty = true;
       try {
         ensureStorageTable(db);
         const insert = db.prepare(
@@ -335,6 +337,7 @@ export function createVectorIndex(
             tableName,
             rows.filter((row) => row.metadataKey === metadataKey),
           );
+          if (!wasDirty) this.vecDirty = false;
         } catch (error) {
           this.vecDirty = true;
           warn(
@@ -345,6 +348,8 @@ export function createVectorIndex(
       return ok(undefined);
     },
     deleteVectors(nodeIds) {
+      const wasDirty = vecDirty;
+      this.vecDirty = true;
       try {
         ensureStorageTable(db);
         const del = db.prepare(
@@ -363,6 +368,7 @@ export function createVectorIndex(
       if (searchAvailable) {
         try {
           driver.delete(db, tableName, nodeIds);
+          if (!wasDirty) this.vecDirty = false;
         } catch {
           this.vecDirty = true;
         }

--- a/src/domain/search/vector-index.ts
+++ b/src/domain/search/vector-index.ts
@@ -193,8 +193,9 @@ export const sqliteVecDriver: VectorAccelerationDriver = {
     const insert = db.prepare(`INSERT INTO ${tableName} (node_id, embedding) VALUES (?, ?)`);
     const tx = db.transaction(() => {
       for (const row of rows) {
-        del.run(row.nodeId);
-        insert.run(row.nodeId, encodeEmbedding(row.embedding));
+        const nodeId = BigInt(row.nodeId);
+        del.run(nodeId);
+        insert.run(nodeId, encodeEmbedding(row.embedding));
       }
     });
     tx();
@@ -202,7 +203,7 @@ export const sqliteVecDriver: VectorAccelerationDriver = {
   delete(db, tableName, nodeIds) {
     const del = db.prepare(`DELETE FROM ${tableName} WHERE node_id = ?`);
     const tx = db.transaction(() => {
-      for (const nodeId of nodeIds) del.run(nodeId);
+      for (const nodeId of nodeIds) del.run(BigInt(nodeId));
     });
     tx();
   },
@@ -409,6 +410,7 @@ export function createVectorIndex(
     },
     rebuildVecIndex() {
       if (!searchAvailable) return ok(undefined);
+      this.vecDirty = true;
       try {
         driver.rebuild(db, tableName, storageRows());
         this.vecDirty = false;
@@ -423,6 +425,7 @@ export function createVectorIndex(
     },
     syncVecIndex() {
       if (!searchAvailable) return ok({ added: 0, removed: 0 });
+      this.vecDirty = true;
       try {
         const result = driver.sync(db, tableName, storageRows());
         this.vecDirty = false;

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -42,7 +42,21 @@ export const DEFAULTS = {
     apiKey: null as string | null,
     apiKeyCommand: null as string | null,
   },
-  search: { defaultMinScore: 0.2, rrfK: 60, topK: 15, similarityWarnThreshold: 0.85 },
+  search: {
+    defaultMinScore: 0.2,
+    rrfK: 60,
+    topK: 15,
+    similarityWarnThreshold: 0.85,
+    rrfWeights: {
+      bm25: 2,
+      bm25Variant: 0.5,
+      vector: 2,
+      vectorVariant: 0.5,
+      hyde: 0.7,
+    },
+    topRankBonus: 0.1,
+    topRankThreshold: 5,
+  },
   ci: { failOnCycles: false, impactThreshold: null as number | null },
   manifesto: {
     rules: {

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -31,6 +31,10 @@ export const DEFAULTS = {
     excludeTests: false,
   },
   embeddings: { model: 'nomic-v1.5', llmProvider: null as string | null },
+  models: {
+    preset: 'codegraph-default',
+    roles: {} as Partial<Record<'embed' | 'rerank' | 'expand' | 'gen', string>>,
+  },
   llm: {
     provider: null as string | null,
     model: null as string | null,

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -30,9 +30,12 @@ export const DEFAULTS = {
     defaultLimit: 20,
     excludeTests: false,
   },
-  embeddings: { model: 'nomic-v1.5', llmProvider: null as string | null },
+  embeddings: {
+    model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+    llmProvider: null as string | null,
+  },
   models: {
-    preset: 'codegraph-default',
+    preset: 'gno-compact',
     roles: {} as Partial<Record<'embed' | 'rerank' | 'expand' | 'gen', string>>,
   },
   llm: {

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -56,6 +56,7 @@ export const DEFAULTS = {
     },
     topRankBonus: 0.1,
     topRankThreshold: 5,
+    nearTopRankBonusMultiplier: 0.4,
   },
   ci: { failOnCycles: false, impactThreshold: null as number | null },
   manifesto: {

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -57,6 +57,12 @@ export const DEFAULTS = {
     topRankBonus: 0.1,
     topRankThreshold: 5,
     nearTopRankBonusMultiplier: 0.4,
+    rerank: {
+      enabled: false,
+      maxCandidates: 20,
+      fusionWeight: 0.4,
+      rerankWeight: 0.6,
+    },
   },
   ci: { failOnCycles: false, impactThreshold: null as number | null },
   manifesto: {

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -311,6 +311,48 @@ const BASE_TOOLS: ToolSchema[] = [
           description:
             'Search mode: hybrid (BM25 + semantic, default), semantic (embeddings only), keyword (BM25 only)',
         },
+        expand: {
+          type: 'boolean',
+          description:
+            'Enable query expansion for hybrid search (default: true for MCP hybrid mode)',
+        },
+        no_expand: {
+          type: 'boolean',
+          description: 'Disable query expansion for this request',
+        },
+        rerank: {
+          type: 'boolean',
+          description: 'Enable reranking for this request when a reranker is configured',
+        },
+        no_rerank: {
+          type: 'boolean',
+          description: 'Disable reranking for this request',
+        },
+        rerank_candidates: {
+          type: 'number',
+          description: 'Number of fused candidates eligible for reranking',
+        },
+        rrf_k: { type: 'number', description: 'RRF k parameter for hybrid fusion' },
+        query_mode: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Structured query mode entries: term:<text>, intent:<text>, or hyde:<text>',
+        },
+        query_modes: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              mode: { type: 'string', enum: ['term', 'intent', 'hyde'] },
+              text: { type: 'string' },
+            },
+          },
+          description: 'Structured query mode objects for agents',
+        },
+        explain: {
+          type: 'boolean',
+          description: 'Include weighted fusion/rerank explanation metadata when available',
+        },
         ...PAGINATION_PROPS,
       },
       required: ['query'],

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -340,13 +340,18 @@ const BASE_TOOLS: ToolSchema[] = [
         query_modes: {
           type: 'array',
           items: {
-            type: 'object',
-            properties: {
-              mode: { type: 'string', enum: ['term', 'intent', 'hyde'] },
-              text: { type: 'string' },
-            },
+            oneOf: [
+              { type: 'string' },
+              {
+                type: 'object',
+                properties: {
+                  mode: { type: 'string', enum: ['term', 'intent', 'hyde'] },
+                  text: { type: 'string' },
+                },
+              },
+            ],
           },
-          description: 'Structured query mode objects for agents',
+          description: 'Structured query mode entries for agents: strings or {mode,text} objects',
         },
         explain: {
           type: 'boolean',

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -334,8 +334,7 @@ const BASE_TOOLS: ToolSchema[] = [
         },
         rrf_k: { type: 'number', description: 'RRF k parameter for hybrid fusion' },
         query_mode: {
-          type: 'array',
-          items: { type: 'string' },
+          oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
           description: 'Structured query mode entries: term:<text>, intent:<text>, or hyde:<text>',
         },
         query_modes: {

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -348,6 +348,7 @@ const BASE_TOOLS: ToolSchema[] = [
                   mode: { type: 'string', enum: ['term', 'intent', 'hyde'] },
                   text: { type: 'string' },
                 },
+                required: ['mode', 'text'],
               },
             ],
           },

--- a/src/mcp/tools/semantic-search.ts
+++ b/src/mcp/tools/semantic-search.ts
@@ -177,7 +177,17 @@ export async function handler(args: SemanticSearchArgs, ctx: McpToolContext): Pr
   }
 
   const semantic = await searchData(input.query, ctx.dbPath, searchOpts).catch(() => null);
-  if (semantic !== null) return semantic;
+  if (semantic !== null) {
+    return {
+      ...semantic,
+      fallback: {
+        mode: 'semantic',
+        reason: 'FTS5 hybrid index unavailable',
+        message:
+          'Hybrid search unavailable because the FTS5 keyword index is missing; returned semantic-only results.',
+      },
+    };
+  }
 
   const keyword = ftsSearchData(input.query, ctx.dbPath, searchOpts);
   if (keyword !== null) {

--- a/src/mcp/tools/semantic-search.ts
+++ b/src/mcp/tools/semantic-search.ts
@@ -3,72 +3,196 @@ import type { McpToolContext } from '../server.js';
 
 export const name = 'semantic_search';
 
+type QueryModeArg = string | { mode?: string; text?: string };
+
 interface SemanticSearchArgs {
   query: string;
   mode?: string;
   limit?: number;
   offset?: number;
   min_score?: number;
+  expand?: boolean;
+  no_expand?: boolean;
+  rerank?: boolean;
+  no_rerank?: boolean;
+  rerank_candidates?: number;
+  rrf_k?: number;
+  query_mode?: string | string[];
+  query_modes?: QueryModeArg[];
+  explain?: boolean;
 }
 
-export async function handler(args: SemanticSearchArgs, ctx: McpToolContext): Promise<unknown> {
-  const mode = args.mode || 'hybrid';
-  const searchOpts = {
+function errorResult(text: string): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeQueryModeArgs(args: SemanticSearchArgs): string[] {
+  const specs: string[] = [];
+  const addSpec = (spec: unknown) => {
+    if (typeof spec === 'string' && spec.trim().length > 0) specs.push(spec);
+  };
+
+  if (Array.isArray(args.query_mode)) {
+    for (const spec of args.query_mode) addSpec(spec);
+  } else {
+    addSpec(args.query_mode);
+  }
+
+  for (const entry of args.query_modes ?? []) {
+    if (typeof entry === 'string') {
+      addSpec(entry);
+    } else if (entry && typeof entry.mode === 'string' && typeof entry.text === 'string') {
+      addSpec(`${entry.mode}:${entry.text}`);
+    }
+  }
+  return specs;
+}
+
+async function buildSearchInput(args: SemanticSearchArgs): Promise<{
+  query: string;
+  queryModes: Array<{ mode: 'term' | 'intent' | 'hyde'; text: string }>;
+  queryTextKind: 'plain' | 'term' | 'intent' | 'empty';
+}> {
+  const { normalizeStructuredQueryInput, parseQueryModeSpecs } = await import(
+    '../../domain/search/search/expansion.js'
+  );
+  const explicitModes = parseQueryModeSpecs(normalizeQueryModeArgs(args));
+  const normalized = normalizeStructuredQueryInput(args.query, explicitModes);
+  return {
+    query: normalized.query,
+    queryModes: normalized.queryModes,
+    queryTextKind: normalized.queryTextKind,
+  };
+}
+
+function buildSearchOpts(
+  args: SemanticSearchArgs,
+  ctx: McpToolContext,
+  queryModes: Array<{ mode: 'term' | 'intent' | 'hyde'; text: string }>,
+  queryTextKind: 'plain' | 'term' | 'intent' | 'empty',
+) {
+  const hasStructuredModes = queryModes.length > 0;
+  const expand = hasStructuredModes ? false : args.no_expand ? false : (args.expand ?? true);
+  const rerank = args.no_rerank ? false : args.rerank;
+  return {
     limit: Math.min(args.limit ?? MCP_DEFAULTS.semantic_search ?? 100, ctx.MCP_MAX_LIMIT),
     offset: effectiveOffset(args),
     minScore: args.min_score,
+    expand,
+    explain: args.explain,
+    rerank,
+    rerankCandidates: args.rerank_candidates,
+    queryModes,
+    queryTextKind,
+    rrfK: args.rrf_k,
   };
+}
+
+export async function handler(args: SemanticSearchArgs, ctx: McpToolContext): Promise<unknown> {
+  let input: Awaited<ReturnType<typeof buildSearchInput>>;
+  try {
+    input = await buildSearchInput(args);
+  } catch (error) {
+    return errorResult(`Invalid semantic_search query_mode input: ${errorMessage(error)}`);
+  }
+
+  const mode = args.mode || 'hybrid';
+  if (!['hybrid', 'semantic', 'keyword'].includes(mode)) {
+    return errorResult(
+      `Invalid semantic_search mode "${mode}". Use "hybrid", "semantic", or "keyword".`,
+    );
+  }
+  const searchOpts = buildSearchOpts(args, ctx, input.queryModes, input.queryTextKind);
 
   if (mode === 'keyword') {
     const { ftsSearchData } = await import('../../domain/search/index.js');
-    const result = ftsSearchData(args.query, ctx.dbPath, searchOpts);
+    const result = ftsSearchData(input.query, ctx.dbPath, searchOpts);
     if (result === null) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: 'No FTS5 index found. Run `codegraph embed` to build the keyword index.',
-          },
-        ],
-        isError: true,
-      };
+      return errorResult(
+        'Keyword search unavailable: no FTS5 index found. Run `codegraph embed` to build the keyword index.',
+      );
     }
     return result;
   }
 
   if (mode === 'semantic') {
     const { searchData } = await import('../../domain/search/index.js');
-    const result = await searchData(args.query, ctx.dbPath, searchOpts);
-    if (result === null) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: 'Semantic search unavailable. Run `codegraph embed` first.',
-          },
-        ],
-        isError: true,
-      };
+    try {
+      const result = await searchData(input.query, ctx.dbPath, searchOpts);
+      if (result === null) {
+        return errorResult(
+          'Semantic search unavailable: no embeddings found or vector search could not run. Run `codegraph embed` first, or use mode="keyword" if an FTS index is available.',
+        );
+      }
+      return result;
+    } catch (error) {
+      return errorResult(
+        `Semantic search unavailable: ${errorMessage(error)}. Run \`codegraph embed\` to rebuild embeddings, check embedding model/runtime configuration, or use mode="keyword".`,
+      );
     }
-    return result;
   }
 
-  // hybrid (default) — falls back to semantic if no FTS5
-  const { hybridSearchData, searchData } = await import('../../domain/search/index.js');
-  let result: unknown = await hybridSearchData(args.query, ctx.dbPath, searchOpts);
-  if (result === null) {
-    result = await searchData(args.query, ctx.dbPath, searchOpts);
-    if (result === null) {
+  // hybrid (default) — new retrieval pipeline with graceful fallbacks for MCP agents.
+  const { ftsSearchData, hybridSearchData, searchData } = await import(
+    '../../domain/search/index.js'
+  );
+  try {
+    const result: unknown = await hybridSearchData(input.query, ctx.dbPath, searchOpts);
+    if (result !== null) return result;
+  } catch (error) {
+    const keyword = ftsSearchData(input.query, ctx.dbPath, searchOpts);
+    if (keyword !== null) {
       return {
-        content: [
-          {
-            type: 'text',
-            text: 'Semantic search unavailable. Run `codegraph embed` first.',
-          },
-        ],
-        isError: true,
+        ...keyword,
+        fallback: {
+          mode: 'keyword',
+          reason: errorMessage(error),
+          message:
+            'Hybrid semantic retrieval unavailable; returned BM25 keyword results. Re-run `codegraph embed` and check embedding/vector/rerank model configuration to restore hybrid search.',
+        },
       };
     }
+    const semantic = await searchData(input.query, ctx.dbPath, searchOpts).catch(() => null);
+    if (semantic !== null) {
+      return {
+        ...semantic,
+        fallback: {
+          mode: 'semantic',
+          reason: errorMessage(error),
+          message:
+            'Hybrid retrieval unavailable because keyword/vector fusion failed; returned semantic-only results.',
+        },
+      };
+    }
+    return errorResult(
+      `Semantic search unavailable: ${errorMessage(error)}. No keyword fallback is available. Run \`codegraph embed\` to build embeddings and the FTS5 keyword index, then retry.`,
+    );
   }
-  return result;
+
+  const semantic = await searchData(input.query, ctx.dbPath, searchOpts).catch(() => null);
+  if (semantic !== null) return semantic;
+
+  const keyword = ftsSearchData(input.query, ctx.dbPath, searchOpts);
+  if (keyword !== null) {
+    return {
+      ...keyword,
+      fallback: {
+        mode: 'keyword',
+        reason: 'FTS5 hybrid index unavailable and semantic embeddings unavailable',
+        message:
+          'Hybrid search unavailable; returned BM25 keyword results. Run `codegraph embed` to rebuild embeddings and the FTS5 index for hybrid search.',
+      },
+    };
+  }
+
+  return errorResult(
+    'Semantic search unavailable: no embeddings or FTS5 keyword index found. Run `codegraph embed` first, then retry.',
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1154,6 +1154,12 @@ export interface CodegraphConfig {
     topRankBonus?: number;
     topRankThreshold?: number;
     nearTopRankBonusMultiplier?: number;
+    rerank?: {
+      enabled?: boolean;
+      maxCandidates?: number;
+      fusionWeight?: number;
+      rerankWeight?: number;
+    };
   };
 
   ci: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1144,6 +1144,15 @@ export interface CodegraphConfig {
     rrfK: number;
     topK: number;
     similarityWarnThreshold: number;
+    rrfWeights?: {
+      bm25?: number;
+      bm25Variant?: number;
+      vector?: number;
+      vectorVariant?: number;
+      hyde?: number;
+    };
+    topRankBonus?: number;
+    topRankThreshold?: number;
   };
 
   ci: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,8 @@ export type LanguageId =
 /** Engine mode selector. */
 export type EngineMode = 'native' | 'wasm' | 'auto';
 
+export type ModelRole = 'embed' | 'rerank' | 'expand' | 'gen';
+
 /** Graph export formats. */
 export type ExportFormat = 'dot' | 'mermaid' | 'json' | 'graphml' | 'graphson' | 'neo4j-csv';
 
@@ -1115,6 +1117,11 @@ export interface CodegraphConfig {
   embeddings: {
     model: string;
     llmProvider: string | null;
+  };
+
+  models?: {
+    preset?: string;
+    roles?: Partial<Record<ModelRole, string>>;
   };
 
   llm: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1153,6 +1153,7 @@ export interface CodegraphConfig {
     };
     topRankBonus?: number;
     topRankThreshold?: number;
+    nearTopRankBonusMultiplier?: number;
   };
 
   ci: {

--- a/tests/benchmarks/retrieval-benchmark.test.ts
+++ b/tests/benchmarks/retrieval-benchmark.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import {
+  BENCHMARK_MODEL_PRESETS,
+  CODE_RETRIEVAL_FIXTURES,
+  runRetrievalBenchmark,
+} from '../../scripts/retrieval-benchmark.js';
+
+describe('retrieval benchmark harness', () => {
+  test('ships code-focused fixtures for every required query category', () => {
+    expect(CODE_RETRIEVAL_FIXTURES.map((fixture) => fixture.category).sort()).toEqual([
+      'ambiguous-natural-language',
+      'code-intent',
+      'graph-aware-symbol-context',
+      'identifier',
+    ]);
+
+    for (const fixture of CODE_RETRIEVAL_FIXTURES) {
+      expect(fixture.query).toBeTruthy();
+      expect(fixture.relevantSymbolIds.length).toBeGreaterThan(0);
+      expect(fixture.documents.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  test('compares current default, notable alternatives, and the GNO/Qwen path in CI-safe smoke mode', async () => {
+    const output = await runRetrievalBenchmark({ mode: 'mock', topK: 3 });
+
+    expect(BENCHMARK_MODEL_PRESETS.map((preset) => preset.id)).toEqual([
+      'current-default',
+      'minilm-baseline',
+      'jina-code',
+      'gno-qwen-compact',
+    ]);
+    expect(output.mode).toBe('mock');
+    expect(output.queries).toHaveLength(4);
+    expect(Object.keys(output.models)).toEqual(BENCHMARK_MODEL_PRESETS.map((preset) => preset.id));
+
+    for (const result of Object.values(output.models)) {
+      expect(result.quality.hitAt1).toBeGreaterThanOrEqual(0);
+      expect(result.quality.hitAt3).toBeGreaterThanOrEqual(result.quality.hitAt1);
+      expect(result.quality.mrr).toBeGreaterThanOrEqual(0);
+      expect(result.runtime.totalMs).toBeGreaterThanOrEqual(0);
+      expect(result.embeddingCost.provider).toBe('local');
+      expect(result.perQuery).toHaveLength(4);
+    }
+  });
+});

--- a/tests/benchmarks/retrieval-benchmark.test.ts
+++ b/tests/benchmarks/retrieval-benchmark.test.ts
@@ -7,17 +7,23 @@ import {
 
 describe('retrieval benchmark harness', () => {
   test('ships code-focused fixtures for every required query category', () => {
-    expect(CODE_RETRIEVAL_FIXTURES.map((fixture) => fixture.category).sort()).toEqual([
+    const requiredCategories = [
       'ambiguous-natural-language',
       'code-intent',
       'graph-aware-symbol-context',
       'identifier',
-    ]);
+    ];
+    const categoryCounts = new Map<string, number>();
 
     for (const fixture of CODE_RETRIEVAL_FIXTURES) {
+      categoryCounts.set(fixture.category, (categoryCounts.get(fixture.category) ?? 0) + 1);
       expect(fixture.query).toBeTruthy();
       expect(fixture.relevantSymbolIds.length).toBeGreaterThan(0);
       expect(fixture.documents.length).toBeGreaterThanOrEqual(3);
+    }
+
+    for (const category of requiredCategories) {
+      expect(categoryCounts.get(category)).toBeGreaterThanOrEqual(1);
     }
   });
 

--- a/tests/search/embed-command.test.ts
+++ b/tests/search/embed-command.test.ts
@@ -38,7 +38,7 @@ describe('embed command model compatibility', () => {
     buildEmbeddingsMock.mockClear();
   });
 
-  test('falls back to legacy embedding model for implicit unsupported preset embed URI', async () => {
+  test('routes implicit supported Qwen GGUF preset embed URI through buildEmbeddings', async () => {
     const config = ctx({ models: { preset: 'gno-compact' } });
 
     expect(resolveModelRoleUri(config.config, 'embed')).toBe(
@@ -49,11 +49,10 @@ describe('embed command model compatibility', () => {
 
     expect(buildEmbeddingsMock).toHaveBeenCalledWith(
       expect.any(String),
-      DEFAULTS.embeddings.model,
+      RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed,
       undefined,
       { strategy: 'structured' },
     );
-    expect(buildEmbeddingsMock.mock.calls[0]?.[1]).not.toMatch(/^hf:/);
   });
 
   test('uses implicit supported role model names without falling back', async () => {
@@ -67,7 +66,7 @@ describe('embed command model compatibility', () => {
     );
   });
 
-  test('preserves explicit unsupported --model so buildEmbeddings reports the existing error', async () => {
+  test('preserves explicit Qwen --model for the port factory', async () => {
     await command.execute?.(
       ['.'],
       { strategy: 'structured', model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF' },

--- a/tests/search/embed-command.test.ts
+++ b/tests/search/embed-command.test.ts
@@ -55,12 +55,12 @@ describe('embed command model compatibility', () => {
     );
   });
 
-  test('uses implicit supported role model names without falling back', async () => {
+  test('routes implicit GNO/Qwen default embed URI through buildEmbeddings', async () => {
     await command.execute?.(['.'], { strategy: 'structured' }, ctx());
 
     expect(buildEmbeddingsMock).toHaveBeenCalledWith(
       expect.any(String),
-      'nomic-ai/nomic-embed-text-v1.5',
+      'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
       undefined,
       { strategy: 'structured' },
     );

--- a/tests/search/embed-command.test.ts
+++ b/tests/search/embed-command.test.ts
@@ -69,13 +69,16 @@ describe('embed command model compatibility', () => {
   test('preserves explicit Qwen --model for the port factory', async () => {
     await command.execute?.(
       ['.'],
-      { strategy: 'structured', model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF' },
+      {
+        strategy: 'structured',
+        model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      },
       ctx({ models: { preset: 'gno-compact' } }),
     );
 
     expect(buildEmbeddingsMock).toHaveBeenCalledWith(
       expect.any(String),
-      'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
+      'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
       undefined,
       { strategy: 'structured' },
     );

--- a/tests/search/embed-command.test.ts
+++ b/tests/search/embed-command.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { CliContext } from '../../src/cli/types.js';
+import { DEFAULTS } from '../../src/infrastructure/config.js';
+import type { CodegraphConfig } from '../../src/types.js';
+
+const buildEmbeddingsMock = vi.fn();
+
+vi.mock('../../src/domain/search/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/domain/search/index.js')>();
+  return {
+    ...actual,
+    buildEmbeddings: buildEmbeddingsMock,
+  };
+});
+
+const { command } = await import('../../src/cli/commands/embed.js');
+const { RETRIEVAL_MODEL_PRESETS, resolveModelRoleUri } = await import(
+  '../../src/domain/search/index.js'
+);
+
+function ctx(config: Partial<CodegraphConfig> = {}): CliContext {
+  return {
+    config: {
+      ...(DEFAULTS as CodegraphConfig),
+      ...config,
+      embeddings: { ...DEFAULTS.embeddings, ...config.embeddings },
+    } as CodegraphConfig,
+    resolveNoTests: () => false,
+    resolveQueryOpts: (opts) => opts,
+    formatSize: (bytes) => `${bytes}B`,
+    outputResult: () => false,
+    program: {} as CliContext['program'],
+  };
+}
+
+describe('embed command model compatibility', () => {
+  beforeEach(() => {
+    buildEmbeddingsMock.mockClear();
+  });
+
+  test('falls back to legacy embedding model for implicit unsupported preset embed URI', async () => {
+    const config = ctx({ models: { preset: 'gno-compact' } });
+
+    expect(resolveModelRoleUri(config.config, 'embed')).toBe(
+      RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed,
+    );
+
+    await command.execute?.(['.'], { strategy: 'structured' }, config);
+
+    expect(buildEmbeddingsMock).toHaveBeenCalledWith(
+      expect.any(String),
+      DEFAULTS.embeddings.model,
+      undefined,
+      { strategy: 'structured' },
+    );
+    expect(buildEmbeddingsMock.mock.calls[0]?.[1]).not.toMatch(/^hf:/);
+  });
+
+  test('uses implicit supported role model names without falling back', async () => {
+    await command.execute?.(['.'], { strategy: 'structured' }, ctx());
+
+    expect(buildEmbeddingsMock).toHaveBeenCalledWith(
+      expect.any(String),
+      'nomic-ai/nomic-embed-text-v1.5',
+      undefined,
+      { strategy: 'structured' },
+    );
+  });
+
+  test('preserves explicit unsupported --model so buildEmbeddings reports the existing error', async () => {
+    await command.execute?.(
+      ['.'],
+      { strategy: 'structured', model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF' },
+      ctx({ models: { preset: 'gno-compact' } }),
+    );
+
+    expect(buildEmbeddingsMock).toHaveBeenCalledWith(
+      expect.any(String),
+      'hf:Qwen/Qwen3-Embedding-0.6B-GGUF',
+      undefined,
+      { strategy: 'structured' },
+    );
+  });
+});

--- a/tests/search/embedder-search.test.ts
+++ b/tests/search/embedder-search.test.ts
@@ -8,25 +8,31 @@ import { initSchema } from '../../src/db/index.js';
 // ─── Mock setup ────────────────────────────────────────────────────────
 
 // Hoisted so the mock factory can reference it
-const { QUERY_VECTORS } = vi.hoisted(() => ({
+const { QUERY_VECTORS, EMBED_BATCH_SIZES } = vi.hoisted(() => ({
   QUERY_VECTORS: new Map(),
+  EMBED_BATCH_SIZES: [] as number[],
 }));
 
 // Mock @huggingface/transformers so embed() returns controlled vectors
 // without downloading or loading a real ML model.
 vi.mock('@huggingface/transformers', () => ({
-  pipeline: async () => async (batch) => {
-    const dim = 384; // must match minilm config
-    const data = new Float32Array(dim * batch.length);
-    for (let t = 0; t < batch.length; t++) {
-      const vec = QUERY_VECTORS.get(batch[t]);
-      if (vec) {
-        for (let i = 0; i < vec.length; i++) {
-          data[t * dim + i] = vec[i];
+  pipeline: async (_task, model) => {
+    const extractor = async (batch) => {
+      EMBED_BATCH_SIZES.push(batch.length);
+      const dim = model === 'Xenova/bge-large-en-v1.5' ? 1024 : 384;
+      const data = new Float32Array(dim * batch.length);
+      for (let t = 0; t < batch.length; t++) {
+        const vec = QUERY_VECTORS.get(batch[t]);
+        if (vec) {
+          for (let i = 0; i < vec.length; i++) {
+            data[t * dim + i] = vec[i];
+          }
         }
       }
-    }
-    return { data };
+      return { data };
+    };
+    extractor.dispose = async () => {};
+    return extractor;
   },
   cos_sim: () => 0,
 }));
@@ -307,6 +313,22 @@ describe('multiSearchData', () => {
     const output = spy.mock.calls.map((c) => c[0]).join('');
     expect(output).not.toContain('very similar');
     spy.mockRestore();
+  });
+
+  test('uses the active model batch size when embedding multiple queries', async () => {
+    const modelDbPath = path.join(tmpDir, 'bge-graph.db');
+    fs.copyFileSync(dbPath, modelDbPath);
+    const db = new Database(modelDbPath);
+    db.prepare("UPDATE embedding_meta SET value = ? WHERE key = 'model'").run(
+      'Xenova/bge-large-en-v1.5',
+    );
+    db.prepare("UPDATE embedding_meta SET value = ? WHERE key = 'dim'").run('1024');
+    db.close();
+
+    EMBED_BATCH_SIZES.length = 0;
+    await multiSearchData(['auth', 'jwt', 'auth', 'jwt', 'auth'], modelDbPath, { minScore: 0.2 });
+
+    expect(EMBED_BATCH_SIZES).toEqual([4, 1]);
   });
 });
 

--- a/tests/search/embedder-search.test.ts
+++ b/tests/search/embedder-search.test.ts
@@ -178,6 +178,8 @@ beforeAll(() => {
   QUERY_VECTORS.set('"formatDate"', makeVec([0, 0, 1]));
   QUERY_VECTORS.set('buildGraph', makeVec([0.2, 0.2, 0.2]));
   QUERY_VECTORS.set('"buildGraph"', makeVec([0.2, 0.2, 0.2]));
+  QUERY_VECTORS.set('auth jwt validate', makeVec([0, 1, 0]));
+  QUERY_VECTORS.set('auth formatDate docs format', makeVec([0, 0, 1]));
 
   // ─── Second DB without FTS5 (for fallback tests) ────────────────────
   noFtsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-nofts-'));
@@ -465,6 +467,43 @@ describe('hybridSearchData', () => {
     const data = await hybridSearchData('auth ; jwt', dbPath, { minScore: 0.01 });
     expect(data).not.toBeNull();
     expect(data.results.length).toBeGreaterThan(0);
+  });
+
+  test('optional expansion routes lexical variants to BM25 and vector/HyDE variants to semantic', async () => {
+    const data = await hybridSearchData('auth', dbPath, {
+      minScore: 0.01,
+      expand: true,
+      expansionProvider: {
+        generate: async () =>
+          '{"lexicalQueries":["auth authenticate"],"vectorQueries":["auth jwt validate"],"hyde":"auth formatDate docs format"}',
+      },
+    });
+
+    expect(data).not.toBeNull();
+    expect(data.results.map((result) => result.name)).toEqual(
+      expect.arrayContaining(['authenticate', 'validateJWT', 'formatDate']),
+    );
+    expect(data.results.find((result) => result.name === 'authenticate')?.bm25Rank).not.toBeNull();
+    expect(
+      data.results.find((result) => result.name === 'validateJWT')?.semanticRank,
+    ).not.toBeNull();
+    expect(
+      data.results.find((result) => result.name === 'formatDate')?.semanticRank,
+    ).not.toBeNull();
+  });
+
+  test('strong exact BM25 signal skips expansion in hybrid search', async () => {
+    const data = await hybridSearchData('authenticate', dbPath, {
+      minScore: 0.01,
+      expand: true,
+      expansionProvider: {
+        generate: async () =>
+          '{"lexicalQueries":["format"],"vectorQueries":["formatDate docs format"],"hyde":"formatDate docs format"}',
+      },
+    });
+
+    expect(data).not.toBeNull();
+    expect(data.results.some((result) => result.name === 'formatDate')).toBe(false);
   });
 });
 

--- a/tests/search/embedding-metadata.test.ts
+++ b/tests/search/embedding-metadata.test.ts
@@ -1,0 +1,231 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, test, vi } from 'vitest';
+import { initSchema } from '../../src/db/index.js';
+import { getEmbeddingMeta } from '../../src/db/repository/embeddings.js';
+import {
+  buildEmbeddings,
+  EMBEDDING_FORMATTER_VERSION,
+  readEmbeddingMetadata,
+  searchData,
+} from '../../src/domain/search/index.js';
+
+const { QUERY_VECTORS } = vi.hoisted(() => ({
+  QUERY_VECTORS: new Map<string, Float32Array>(),
+}));
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: async (_task: string, model: string) => {
+    const dim =
+      model.includes('jina-embeddings-v2-base-code') || model.includes('nomic') ? 768 : 384;
+    const extractor = async (batch: string[]) => {
+      const data = new Float32Array(dim * batch.length);
+      for (let t = 0; t < batch.length; t++) {
+        const vec = QUERY_VECTORS.get(batch[t]) ?? new Float32Array(dim);
+        for (let i = 0; i < Math.min(dim, vec.length); i++) data[t * dim + i] = vec[i]!;
+      }
+      return { data };
+    };
+    extractor.dispose = async () => {};
+    return extractor;
+  },
+  cos_sim: () => 0,
+}));
+
+function vec(dim: number, first = 1): Float32Array {
+  const v = new Float32Array(dim);
+  v[0] = first;
+  return v;
+}
+
+function makeDb(dir: string): string {
+  const dbPath = path.join(dir, 'graph.db');
+  const db = new Database(dbPath);
+  initSchema(db);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS embeddings (
+      node_id INTEGER PRIMARY KEY,
+      vector BLOB NOT NULL,
+      text_preview TEXT,
+      full_text TEXT,
+      FOREIGN KEY(node_id) REFERENCES nodes(id)
+    );
+    CREATE TABLE IF NOT EXISTS embedding_meta (key TEXT PRIMARY KEY, value TEXT);
+    CREATE VIRTUAL TABLE IF NOT EXISTS fts_index USING fts5(name, content, tokenize='unicode61');
+  `);
+  db.prepare('INSERT INTO nodes (name, kind, file, line) VALUES (?, ?, ?, ?)').run(
+    'findAuth',
+    'function',
+    'src/auth.ts',
+    1,
+  );
+  db.close();
+  return dbPath;
+}
+
+function seedSearchDb(dir: string, metadata: Record<string, string>): string {
+  const dbPath = makeDb(dir);
+  const db = new Database(dbPath);
+  const nodeId = db.prepare('SELECT id FROM nodes LIMIT 1').get() as { id: number };
+  const rowVec = vec(768);
+  db.prepare(
+    'INSERT INTO embeddings (node_id, vector, text_preview, full_text) VALUES (?, ?, ?, ?)',
+  ).run(
+    nodeId.id,
+    Buffer.from(rowVec.buffer),
+    'findAuth (function) -- src/auth.ts:1',
+    'function findAuth() {}',
+  );
+  const insertMeta = db.prepare('INSERT INTO embedding_meta (key, value) VALUES (?, ?)');
+  for (const [key, value] of Object.entries(metadata)) insertMeta.run(key, value);
+  db.close();
+  return dbPath;
+}
+
+describe('embedding metadata', () => {
+  test('embed records legacy and model-aware metadata for fresh vectors', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-fresh-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'src'));
+      fs.writeFileSync(
+        path.join(dir, 'src/auth.ts'),
+        'export function findAuth() { return true; }\n',
+      );
+      const dbPath = makeDb(dir);
+
+      await buildEmbeddings(dir, 'minilm', dbPath, {
+        strategy: 'structured',
+        embeddingPort: { embedBatch: async (texts) => texts.map(() => vec(384)) },
+      });
+
+      const db = new Database(dbPath, { readonly: true });
+      expect(getEmbeddingMeta(db, 'model')).toBe('Xenova/all-MiniLM-L6-v2');
+      expect(getEmbeddingMeta(db, 'dim')).toBe('384');
+      expect(getEmbeddingMeta(db, 'strategy')).toBe('structured');
+      expect(getEmbeddingMeta(db, 'built_at')).toMatch(/T/);
+      expect(getEmbeddingMeta(db, 'model_uri')).toBe('Xenova/all-MiniLM-L6-v2');
+      expect(getEmbeddingMeta(db, 'dimension')).toBe('384');
+      expect(getEmbeddingMeta(db, 'compatibility_profile')).toBe('default');
+      expect(getEmbeddingMeta(db, 'formatter_version')).toBe(EMBEDDING_FORMATTER_VERSION);
+      expect(getEmbeddingMeta(db, 'build_timestamp')).toMatch(/T/);
+      db.close();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('legacy metadata can still be read without new keys', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-legacy-'));
+    try {
+      const dbPath = seedSearchDb(dir, {
+        model: 'nomic-ai/nomic-embed-text-v1.5',
+        dim: '768',
+        strategy: 'structured',
+        built_at: '2026-01-01T00:00:00.000Z',
+      });
+      const db = new Database(dbPath, { readonly: true });
+      expect(readEmbeddingMetadata(db)).toMatchObject({
+        modelUri: 'nomic-ai/nomic-embed-text-v1.5',
+        dimension: 768,
+        strategy: 'structured',
+        builtAt: '2026-01-01T00:00:00.000Z',
+        isLegacy: true,
+      });
+      db.close();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('embed warns before rebuilding stale stored metadata', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-embed-stale-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'src'));
+      fs.writeFileSync(
+        path.join(dir, 'src/auth.ts'),
+        'export function findAuth() { return true; }\n',
+      );
+      const dbPath = makeDb(dir);
+      const db = new Database(dbPath);
+      const insertMeta = db.prepare('INSERT INTO embedding_meta (key, value) VALUES (?, ?)');
+      insertMeta.run('model', 'Xenova/all-MiniLM-L6-v2');
+      insertMeta.run('model_uri', 'Xenova/all-MiniLM-L6-v2');
+      insertMeta.run('dim', '384');
+      insertMeta.run('dimension', '384');
+      insertMeta.run('strategy', 'structured');
+      insertMeta.run('compatibility_profile', 'default');
+      insertMeta.run('formatter_version', 'old-codegraph-symbol-format');
+      db.close();
+
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await buildEmbeddings(dir, 'minilm', dbPath, {
+        strategy: 'structured',
+        embeddingPort: { embedBatch: async (texts) => texts.map(() => vec(384)) },
+      });
+      const stderr = spy.mock.calls.map((c) => c[0]).join('');
+      spy.mockRestore();
+      expect(stderr).toContain('Stored embeddings may be stale');
+      expect(stderr).toContain('formatter version');
+      expect(stderr).toContain('codegraph embed --model minilm --strategy structured');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('search warns when stored model metadata does not match the active model', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-model-mismatch-'));
+    try {
+      const dbPath = seedSearchDb(dir, {
+        model: 'nomic-ai/nomic-embed-text-v1.5',
+        model_uri: 'nomic-ai/nomic-embed-text-v1.5',
+        dim: '768',
+        dimension: '768',
+        strategy: 'structured',
+        compatibility_profile: 'default',
+        formatter_version: EMBEDDING_FORMATTER_VERSION,
+        built_at: '2026-01-01T00:00:00.000Z',
+        build_timestamp: '2026-01-01T00:00:00.000Z',
+      });
+      QUERY_VECTORS.set('auth', vec(768));
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await searchData('auth', dbPath, { model: 'jina-code', minScore: 0.1 });
+      const stderr = spy.mock.calls.map((c) => c[0]).join('');
+      spy.mockRestore();
+      expect(stderr).toContain('Stored embeddings may be stale');
+      expect(stderr).toContain('model URI');
+      expect(stderr).toContain('codegraph embed');
+      expect(stderr).toContain('jina-code');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('search warns when stored formatter metadata does not match the active formatter', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-formatter-mismatch-'));
+    try {
+      const dbPath = seedSearchDb(dir, {
+        model: 'nomic-ai/nomic-embed-text-v1.5',
+        model_uri: 'nomic-ai/nomic-embed-text-v1.5',
+        dim: '768',
+        dimension: '768',
+        strategy: 'structured',
+        compatibility_profile: 'default',
+        formatter_version: 'old-codegraph-symbol-format',
+        built_at: '2026-01-01T00:00:00.000Z',
+        build_timestamp: '2026-01-01T00:00:00.000Z',
+      });
+      QUERY_VECTORS.set('auth', vec(768));
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await searchData('auth', dbPath, { minScore: 0.1 });
+      const stderr = spy.mock.calls.map((c) => c[0]).join('');
+      spy.mockRestore();
+      expect(stderr).toContain('Stored embeddings may be stale');
+      expect(stderr).toContain('formatter version');
+      expect(stderr).toContain('codegraph embed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/search/embedding-metadata.test.ts
+++ b/tests/search/embedding-metadata.test.ts
@@ -65,7 +65,11 @@ function makeDb(dir: string): string {
   return dbPath;
 }
 
-function seedSearchDb(dir: string, metadata: Record<string, string>): string {
+function seedSearchDb(
+  dir: string,
+  metadata: Record<string, string>,
+  buildMetadata: Record<string, string> = {},
+): string {
   const dbPath = makeDb(dir);
   const db = new Database(dbPath);
   const nodeId = db.prepare('SELECT id FROM nodes LIMIT 1').get() as { id: number };
@@ -80,8 +84,24 @@ function seedSearchDb(dir: string, metadata: Record<string, string>): string {
   );
   const insertMeta = db.prepare('INSERT INTO embedding_meta (key, value) VALUES (?, ?)');
   for (const [key, value] of Object.entries(metadata)) insertMeta.run(key, value);
+  const insertBuildMeta = db.prepare('INSERT INTO build_meta (key, value) VALUES (?, ?)');
+  for (const [key, value] of Object.entries(buildMetadata)) insertBuildMeta.run(key, value);
   db.close();
   return dbPath;
+}
+
+function freshNomicMetadata(timestamp: string): Record<string, string> {
+  return {
+    model: 'nomic-ai/nomic-embed-text-v1.5',
+    model_uri: 'nomic-ai/nomic-embed-text-v1.5',
+    dim: '768',
+    dimension: '768',
+    strategy: 'structured',
+    compatibility_profile: 'default',
+    formatter_version: EMBEDDING_FORMATTER_VERSION,
+    built_at: timestamp,
+    build_timestamp: timestamp,
+  };
 }
 
 describe('embedding metadata', () => {
@@ -224,6 +244,65 @@ describe('embedding metadata', () => {
       expect(stderr).toContain('Stored embeddings may be stale');
       expect(stderr).toContain('formatter version');
       expect(stderr).toContain('codegraph embed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('search warns when embedding metadata is older than graph build metadata', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-graph-stale-'));
+    try {
+      const dbPath = seedSearchDb(dir, freshNomicMetadata('2026-01-01T00:00:00.000Z'), {
+        built_at: '2026-01-02T00:00:00.000Z',
+      });
+      QUERY_VECTORS.set('auth', vec(768));
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await searchData('auth', dbPath, { minScore: 0.1 });
+      const stderr = spy.mock.calls.map((c) => c[0]).join('');
+      spy.mockRestore();
+      expect(stderr).toContain('Stored embeddings may be stale');
+      expect(stderr).toContain('embedding build timestamp');
+      expect(stderr).toContain('older than graph build timestamp');
+      expect(stderr).toContain('codegraph embed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ['equal', '2026-01-02T00:00:00.000Z'],
+    ['newer', '2026-01-03T00:00:00.000Z'],
+  ])('search does not warn when embedding metadata is %s to graph build metadata', async (_label, embeddingTimestamp) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-graph-fresh-'));
+    try {
+      const dbPath = seedSearchDb(dir, freshNomicMetadata(embeddingTimestamp), {
+        built_at: '2026-01-02T00:00:00.000Z',
+      });
+      QUERY_VECTORS.set('auth', vec(768));
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await searchData('auth', dbPath, { minScore: 0.1 });
+      const stderr = spy.mock.calls.map((c) => c[0]).join('');
+      spy.mockRestore();
+      expect(stderr).not.toContain('Stored embeddings may be stale');
+      expect(stderr).not.toContain('older than graph build timestamp');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('legacy built_at embedding timestamp is honored for graph staleness diagnostics', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-meta-graph-legacy-built-at-'));
+    try {
+      const metadata = freshNomicMetadata('2026-01-01T00:00:00.000Z');
+      delete metadata.build_timestamp;
+      const dbPath = seedSearchDb(dir, metadata, { built_at: '2026-01-02T00:00:00.000Z' });
+      QUERY_VECTORS.set('auth', vec(768));
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await searchData('auth', dbPath, { minScore: 0.1 });
+      const stderr = spy.mock.calls.map((c) => c[0]).join('');
+      spy.mockRestore();
+      expect(stderr).toContain('Stored embeddings may be stale');
+      expect(stderr).toContain('embedding build timestamp');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/search/embedding-port.test.ts
+++ b/tests/search/embedding-port.test.ts
@@ -105,6 +105,39 @@ describe('embedWithRecovery', () => {
 });
 
 describe('buildEmbeddings embedding port integration', () => {
+  test('uses legacy transformer model-specific batch sizes with the port-backed builder path', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-port-batch-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'math.js'), 'export function f0() {}\n');
+      fs.mkdirSync(path.join(tmpDir, '.codegraph'), { recursive: true });
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const db = new Database(dbPath);
+      initSchema(db);
+      const insert = db.prepare(
+        'INSERT INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      );
+      for (let i = 0; i < 9; i++) insert.run(`f${i}`, 'function', 'math.js', 1, 1);
+      db.close();
+
+      const calls: number[] = [];
+      const port: EmbeddingPort = {
+        embedBatch: vi.fn(async (texts) => {
+          calls.push(texts.length);
+          return texts.map((_, index) => vec(index));
+        }),
+      };
+
+      await buildEmbeddings(tmpDir, 'nomic-v1.5', dbPath, {
+        strategy: 'structured',
+        embeddingPort: port,
+      });
+
+      expect(calls).toEqual([8, 1]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test('stores vectors and FTS rows from a mocked embedding port', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-port-integration-'));
     try {

--- a/tests/search/embedding-port.test.ts
+++ b/tests/search/embedding-port.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { initSchema } from '../../src/db/index.js';
 import { buildEmbeddings } from '../../src/domain/search/generator.js';
 import { type EmbeddingPort, embedWithRecovery } from '../../src/domain/search/ports.js';
+import { EngineError } from '../../src/shared/errors.js';
 
 function vec(value: number): Float32Array {
   return new Float32Array([value, value + 0.5]);
@@ -84,6 +85,23 @@ describe('embedWithRecovery', () => {
       embedWithRecovery(port, ['good', 'bad', 'also-good'], { batchSize: 3 }),
     ).rejects.toThrow(/Failed to embed 1 of 3 item\(s\).*bad input: bad/s);
   });
+
+  test('rethrows EngineError unchanged without retrying or wrapping', async () => {
+    const engineError = new EngineError('install @huggingface/transformers', {
+      code: 'ENGINE_UNAVAILABLE',
+    });
+    const port: EmbeddingPort = {
+      embedBatch: vi.fn(async () => {
+        throw engineError;
+      }),
+      reset: vi.fn(),
+    };
+
+    await expect(embedWithRecovery(port, ['a', 'b'], { batchSize: 2 })).rejects.toBe(engineError);
+    expect(port.embedBatch).toHaveBeenCalledTimes(1);
+    expect(port.embedBatch).toHaveBeenCalledWith(['a', 'b']);
+    expect(port.reset).not.toHaveBeenCalled();
+  });
 });
 
 describe('buildEmbeddings embedding port integration', () => {
@@ -103,8 +121,10 @@ describe('buildEmbeddings embedding port integration', () => {
         .run('add', 'function', 'math.js', 1, 1).lastInsertRowid;
       db.close();
 
+      const backing = new Float32Array([99, 0.25, 0.75, 100]);
+      const vector = new Float32Array(backing.buffer, Float32Array.BYTES_PER_ELEMENT, 2);
       const port: EmbeddingPort = {
-        embedBatch: vi.fn(async (texts) => texts.map(() => new Float32Array([0.25, 0.75]))),
+        embedBatch: vi.fn(async (texts) => texts.map(() => vector)),
       };
 
       await buildEmbeddings(tmpDir, 'minilm', dbPath, { strategy: 'source', embeddingPort: port });

--- a/tests/search/embedding-port.test.ts
+++ b/tests/search/embedding-port.test.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, test, vi } from 'vitest';
+import { initSchema } from '../../src/db/index.js';
+import { buildEmbeddings } from '../../src/domain/search/generator.js';
+import { type EmbeddingPort, embedWithRecovery } from '../../src/domain/search/ports.js';
+
+function vec(value: number): Float32Array {
+  return new Float32Array([value, value + 0.5]);
+}
+
+describe('embedWithRecovery', () => {
+  test('embeds a successful trusted batch in one port call', async () => {
+    const port: EmbeddingPort = {
+      embedBatch: vi.fn(async (texts) => texts.map((_, index) => vec(index))),
+    };
+
+    const result = await embedWithRecovery(port, ['a', 'b', 'c'], { batchSize: 3 });
+
+    expect(port.embedBatch).toHaveBeenCalledTimes(1);
+    expect(port.embedBatch).toHaveBeenCalledWith(['a', 'b', 'c']);
+    expect(result).toEqual([vec(0), vec(1), vec(2)]);
+  });
+
+  test('recovers from a failed batch by splitting into smaller batches', async () => {
+    const calls: string[][] = [];
+    const port: EmbeddingPort = {
+      embedBatch: vi.fn(async (texts) => {
+        calls.push([...texts]);
+        if (texts.length === 4) throw new Error('batch too large');
+        return texts.map((text) => vec(text.charCodeAt(0)));
+      }),
+      reset: vi.fn(),
+    };
+
+    const result = await embedWithRecovery(port, ['a', 'b', 'c', 'd'], { batchSize: 4 });
+
+    expect(calls).toEqual([
+      ['a', 'b', 'c', 'd'],
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+    expect(port.reset).toHaveBeenCalledTimes(1);
+    expect(result.map((v) => v[0])).toEqual([97, 98, 99, 100]);
+  });
+
+  test('falls back to individual items when smaller batches fail', async () => {
+    const calls: string[][] = [];
+    const port: EmbeddingPort = {
+      embedBatch: vi.fn(async (texts) => {
+        calls.push([...texts]);
+        if (texts.length > 1) throw new Error(`cannot embed ${texts.length}`);
+        return [vec(texts[0]!.length)];
+      }),
+      reset: vi.fn(),
+    };
+
+    const result = await embedWithRecovery(port, ['aa', 'bbb', 'c', 'dddd'], { batchSize: 4 });
+
+    expect(calls).toEqual([
+      ['aa', 'bbb', 'c', 'dddd'],
+      ['aa', 'bbb'],
+      ['aa'],
+      ['bbb'],
+      ['c', 'dddd'],
+      ['c'],
+      ['dddd'],
+    ]);
+    expect(port.reset).toHaveBeenCalledTimes(3);
+    expect(result.map((v) => v[0])).toEqual([2, 3, 1, 4]);
+  });
+
+  test('reports partial item failures without dropping successful embeddings', async () => {
+    const port: EmbeddingPort = {
+      embedBatch: vi.fn(async (texts) => {
+        if (texts.length > 1 || texts[0] === 'bad') throw new Error(`bad input: ${texts[0]}`);
+        return [vec(texts[0]!.length)];
+      }),
+    };
+
+    await expect(
+      embedWithRecovery(port, ['good', 'bad', 'also-good'], { batchSize: 3 }),
+    ).rejects.toThrow(/Failed to embed 1 of 3 item\(s\).*bad input: bad/s);
+  });
+});
+
+describe('buildEmbeddings embedding port integration', () => {
+  test('stores vectors and FTS rows from a mocked embedding port', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-port-integration-'));
+    try {
+      fs.writeFileSync(
+        path.join(tmpDir, 'math.js'),
+        'export function add(a, b) { return a + b; }\n',
+      );
+      fs.mkdirSync(path.join(tmpDir, '.codegraph'), { recursive: true });
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const db = new Database(dbPath);
+      initSchema(db);
+      const nodeId = db
+        .prepare('INSERT INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)')
+        .run('add', 'function', 'math.js', 1, 1).lastInsertRowid;
+      db.close();
+
+      const port: EmbeddingPort = {
+        embedBatch: vi.fn(async (texts) => texts.map(() => new Float32Array([0.25, 0.75]))),
+      };
+
+      await buildEmbeddings(tmpDir, 'minilm', dbPath, { strategy: 'source', embeddingPort: port });
+
+      const embeddedText = (port.embedBatch as ReturnType<typeof vi.fn>).mock.calls[0][0][0];
+      expect(embeddedText).toContain('function add');
+      expect(embeddedText).toContain('export function add(a, b) { return a + b; }');
+
+      const readDb = new Database(dbPath, { readonly: true });
+      const embedding = readDb
+        .prepare('SELECT vector, full_text FROM embeddings WHERE node_id = ?')
+        .get(nodeId) as { vector: Buffer; full_text: string };
+      const fts = readDb
+        .prepare('SELECT name, content FROM fts_index WHERE rowid = ?')
+        .get(nodeId) as { name: string; content: string };
+      const dim = readDb.prepare("SELECT value FROM embedding_meta WHERE key = 'dim'").get() as {
+        value: string;
+      };
+      readDb.close();
+
+      const stored = new Float32Array(
+        embedding.vector.buffer,
+        embedding.vector.byteOffset,
+        embedding.vector.byteLength / Float32Array.BYTES_PER_ELEMENT,
+      );
+      expect(Array.from(stored)).toEqual([0.25, 0.75]);
+      expect(embedding.full_text).toBe(embeddedText);
+      expect(fts).toEqual({ name: 'add', content: embedding.full_text });
+      expect(dim.value).toBe('2');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/search/expansion.test.ts
+++ b/tests/search/expansion.test.ts
@@ -118,6 +118,39 @@ describe('query expansion parsing and guardrails', () => {
     expect(guarded.hyde).toBeUndefined();
   });
 
+  test('does not treat quoted negations as positive quoted phrase anchors', () => {
+    const guarded = applyExpansionGuardrails('AuthService -"legacy code" migration', {
+      lexicalQueries: ['AuthService -"legacy code" migration plan'],
+      vectorQueries: ['AuthService -"legacy code" migration details'],
+    });
+
+    expect(guarded.lexicalQueries).toContain('AuthService -"legacy code"');
+    expect(guarded.lexicalQueries).not.toContain('AuthService "legacy code" -"legacy code"');
+    expect(guarded.lexicalQueries).toContain('AuthService -"legacy code" migration plan');
+    expect(guarded.vectorQueries).toEqual(['AuthService -"legacy code" migration details']);
+  });
+
+  test('rejects positive reintroduction of quoted negation phrases', () => {
+    const guarded = applyExpansionGuardrails('AuthService -"legacy code" migration', {
+      lexicalQueries: [
+        'AuthService -"legacy code" "legacy code" migration',
+        'AuthService -"legacy code" migration',
+      ],
+      vectorQueries: [
+        'AuthService -"legacy code" discusses legacy code migration',
+        'AuthService -"legacy code" migration guide',
+      ],
+      hyde: 'AuthService -"legacy code" migration warns about legacy code paths.',
+    });
+
+    expect(guarded.lexicalQueries).not.toContain(
+      'AuthService -"legacy code" "legacy code" migration',
+    );
+    expect(guarded.lexicalQueries).toContain('AuthService -"legacy code" migration');
+    expect(guarded.vectorQueries).toEqual(['AuthService -"legacy code" migration guide']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
   test('returns null on invalid output and falls back on provider failure or timeout', async () => {
     expect(parseExpansionOutput('not json', 'auth')).toBeNull();
 

--- a/tests/search/expansion.test.ts
+++ b/tests/search/expansion.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'vitest';
 import {
   applyExpansionGuardrails,
   expandOrFallback,
-  hasStrongBm25Signal,
   parseExpansionOutput,
   routeExpandedQueries,
 } from '../../src/domain/search/search/expansion.js';
@@ -79,6 +78,46 @@ describe('query expansion parsing and guardrails', () => {
     expect(guarded.hyde).toBeUndefined();
   });
 
+  test('treats identifier-like code tokens with underscores as critical anchors', () => {
+    const guarded = applyExpansionGuardrails('parse_url migration', {
+      lexicalQueries: ['url parser migration', 'parse_url migration steps'],
+      vectorQueries: ['URL parser migration', 'parse_url migration guide'],
+      hyde: 'This migration updates URL parser behavior without naming the identifier.',
+    });
+
+    expect(guarded.lexicalQueries).toContain('parse_url');
+    expect(guarded.lexicalQueries).not.toContain('url parser migration');
+    expect(guarded.vectorQueries).toEqual(['parse_url migration guide']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
+  test('does not parse hyphenated symbols as negation anchors', () => {
+    const guarded = applyExpansionGuardrails('foo-bar migration', {
+      lexicalQueries: ['foo-bar migration plan'],
+      vectorQueries: ['foo-bar migration notes'],
+    });
+
+    expect(guarded.lexicalQueries).not.toContain('-bar');
+    expect(guarded.lexicalQueries).toContain('foo-bar migration plan');
+    expect(guarded.vectorQueries).toEqual(['foo-bar migration notes']);
+  });
+
+  test('rejects positive occurrence of negated values outside explicit negation spans', () => {
+    const guarded = applyExpansionGuardrails('AuthService -legacy migration', {
+      lexicalQueries: ['AuthService -legacy legacy migration', 'AuthService -legacy migration'],
+      vectorQueries: [
+        'AuthService -legacy legacy migration details',
+        'AuthService -legacy migration details',
+      ],
+      hyde: 'AuthService -legacy migration should still describe legacy compatibility positively.',
+    });
+
+    expect(guarded.lexicalQueries).not.toContain('AuthService -legacy legacy migration');
+    expect(guarded.lexicalQueries).toContain('AuthService -legacy migration');
+    expect(guarded.vectorQueries).toEqual(['AuthService -legacy migration details']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
   test('returns null on invalid output and falls back on provider failure or timeout', async () => {
     expect(parseExpansionOutput('not json', 'auth')).toBeNull();
 
@@ -105,13 +144,6 @@ describe('query expansion parsing and guardrails', () => {
 
 describe('query expansion routing', () => {
   test('skips expansion for exact-name BM25 hits even with tiny FTS5 scores', async () => {
-    expect(
-      hasStrongBm25Signal([
-        { name: 'authenticate', bm25Score: 0.95 },
-        { name: 'authMiddleware', bm25Score: 0.7 },
-      ]),
-    ).toBe(true);
-
     const routed = await routeExpandedQueries(
       'authenticate',
       {

--- a/tests/search/expansion.test.ts
+++ b/tests/search/expansion.test.ts
@@ -118,6 +118,40 @@ describe('query expansion parsing and guardrails', () => {
     expect(guarded.hyde).toBeUndefined();
   });
 
+  test('preserves dotted unquoted negations and rejects positive reintroduction', () => {
+    const guarded = applyExpansionGuardrails('debug -Node.js runtime', {
+      lexicalQueries: ['debug -Node.js runtime guide', 'debug -Node runtime Node.js guide'],
+      vectorQueries: ['debug -Node.js runtime details', 'debug -Node.js Node.js runtime details'],
+      hyde: 'Debugging -Node.js runtime code should still discuss Node.js behavior positively.',
+    });
+
+    expect(guarded.lexicalQueries).toContain('-Node.js');
+    expect(guarded.lexicalQueries).toContain('debug -Node.js runtime guide');
+    expect(guarded.lexicalQueries).not.toContain('debug -Node runtime Node.js guide');
+    expect(guarded.vectorQueries).toEqual(['debug -Node.js runtime details']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
+  test('keeps dotted negated symbols from becoming positive critical entities', () => {
+    const guarded = applyExpansionGuardrails('audit -React.useEffect cleanup', {
+      lexicalQueries: [
+        'audit -React.useEffect cleanup plan',
+        'audit -React useEffect cleanup plan',
+      ],
+      vectorQueries: [
+        'audit -React.useEffect cleanup details',
+        'audit -React.useEffect React.useEffect cleanup details',
+      ],
+      hyde: 'Audit -React.useEffect cleanup paths without recommending React.useEffect.',
+    });
+
+    expect(guarded.lexicalQueries[0]).toBe('-React.useEffect');
+    expect(guarded.lexicalQueries).toContain('audit -React.useEffect cleanup plan');
+    expect(guarded.lexicalQueries).not.toContain('audit -React useEffect cleanup plan');
+    expect(guarded.vectorQueries).toEqual(['audit -React.useEffect cleanup details']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
   test('does not treat quoted negations as positive quoted phrase anchors', () => {
     const guarded = applyExpansionGuardrails('AuthService -"legacy code" migration', {
       lexicalQueries: ['AuthService -"legacy code" migration plan'],

--- a/tests/search/expansion.test.ts
+++ b/tests/search/expansion.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import {
+  applyExpansionGuardrails,
+  expandOrFallback,
+  hasStrongBm25Signal,
+  parseExpansionOutput,
+  routeExpandedQueries,
+} from '../../src/domain/search/search/expansion.js';
+
+describe('query expansion parsing and guardrails', () => {
+  test('parses JSON embedded in model output and caps variants', () => {
+    const parsed = parseExpansionOutput(
+      'text before {"lexicalQueries":["auth login","auth signin","auth token","auth session","auth user","auth extra"],"vectorQueries":["auth users","authorization flow"],"hyde":"auth modules authenticate users and issue tokens."} text after',
+      'auth',
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.lexicalQueries).toHaveLength(5);
+    expect(parsed?.lexicalQueries).toContain('auth login');
+    expect(parsed?.vectorQueries).toContain('auth users');
+    expect(parsed?.hyde).toContain('auth modules');
+  });
+
+  test('preserves technical anchors and filters drifted variants', () => {
+    const guarded = applyExpansionGuardrails('find C++ "JWT token" -legacy AuthService', {
+      lexicalQueries: ['unrelated database migration', 'AuthService validates JWT token'],
+      vectorQueries: ['payments reconciliation', 'AuthService validates JWT token in C++'],
+      hyde: 'This passage is about cooking dinner.',
+    });
+
+    expect(guarded.lexicalQueries[0]).toContain('C++');
+    expect(guarded.lexicalQueries[0]).toContain('"JWT token"');
+    expect(guarded.lexicalQueries[0]).toContain('-legacy');
+    expect(guarded.lexicalQueries[0]).toContain('AuthService');
+    expect(guarded.lexicalQueries).not.toContain('unrelated database migration');
+    expect(guarded.vectorQueries).toEqual(['AuthService validates JWT token in C++']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
+  test('returns null on invalid output and falls back on provider failure or timeout', async () => {
+    expect(parseExpansionOutput('not json', 'auth')).toBeNull();
+
+    await expect(
+      expandOrFallback('auth', {
+        enabled: true,
+        provider: {
+          generate: async () => {
+            throw new Error('boom');
+          },
+        },
+      }),
+    ).resolves.toBeNull();
+
+    await expect(
+      expandOrFallback('auth', {
+        enabled: true,
+        timeoutMs: 1,
+        provider: { generate: () => new Promise<string>(() => {}) },
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('query expansion routing', () => {
+  test('skips expansion for strong BM25 score and gap', async () => {
+    expect(
+      hasStrongBm25Signal([
+        { name: 'authenticate', bm25Score: 0.95 },
+        { name: 'authMiddleware', bm25Score: 0.7 },
+      ]),
+    ).toBe(true);
+
+    const routed = await routeExpandedQueries(
+      'authenticate',
+      {
+        enabled: true,
+        provider: {
+          generate: async () =>
+            '{"lexicalQueries":["jwt"],"vectorQueries":["jwt"],"hyde":"jwt token validation"}',
+        },
+      },
+      [
+        { name: 'authenticate', bm25Score: 0.95 },
+        { name: 'authMiddleware', bm25Score: 0.7 },
+      ],
+    );
+
+    expect(routed.skipped).toBe('strong_bm25');
+    expect(routed.bm25Queries).toEqual(['authenticate']);
+    expect(routed.semanticQueries).toEqual(['authenticate']);
+  });
+
+  test('routes lexical variants only to BM25 and vector/HyDE variants only to semantic', async () => {
+    const routed = await routeExpandedQueries(
+      'auth',
+      {
+        enabled: true,
+        provider: {
+          generate: async () =>
+            '{"lexicalQueries":["auth login"],"vectorQueries":["auth token validation"],"hyde":"auth middleware validates tokens for requests"}',
+        },
+      },
+      [],
+    );
+
+    expect(routed.bm25Queries).toEqual(['auth', 'auth login']);
+    expect(routed.semanticQueries).toEqual([
+      'auth',
+      'auth token validation',
+      'auth middleware validates tokens for requests',
+    ]);
+  });
+
+  test('degrades to original query when no expansion provider is available', async () => {
+    const routed = await routeExpandedQueries('auth', { enabled: true }, []);
+
+    expect(routed.skipped).toBe('no_provider');
+    expect(routed.bm25Queries).toEqual(['auth']);
+    expect(routed.semanticQueries).toEqual(['auth']);
+  });
+});

--- a/tests/search/expansion.test.ts
+++ b/tests/search/expansion.test.ts
@@ -24,7 +24,7 @@ describe('query expansion parsing and guardrails', () => {
   test('preserves technical anchors and filters drifted variants', () => {
     const guarded = applyExpansionGuardrails('find C++ "JWT token" -legacy AuthService', {
       lexicalQueries: ['unrelated database migration', 'AuthService validates JWT token'],
-      vectorQueries: ['payments reconciliation', 'AuthService validates JWT token in C++'],
+      vectorQueries: ['payments reconciliation', 'AuthService validates JWT token in C++ -legacy'],
       hyde: 'This passage is about cooking dinner.',
     });
 
@@ -33,7 +33,49 @@ describe('query expansion parsing and guardrails', () => {
     expect(guarded.lexicalQueries[0]).toContain('-legacy');
     expect(guarded.lexicalQueries[0]).toContain('AuthService');
     expect(guarded.lexicalQueries).not.toContain('unrelated database migration');
-    expect(guarded.vectorQueries).toEqual(['AuthService validates JWT token in C++']);
+    expect(guarded.vectorQueries).toEqual(['AuthService validates JWT token in C++ -legacy']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
+  test('rejects negation drift and does not let positive negated tokens satisfy anchors', () => {
+    const guarded = applyExpansionGuardrails('AuthService -legacy', {
+      lexicalQueries: ['legacy auth migration', 'AuthService migration'],
+      vectorQueries: ['legacy auth migration', 'AuthService migration -legacy'],
+      hyde: 'AuthService migration recommends legacy compatibility.',
+    });
+
+    expect(guarded.lexicalQueries).toContain('AuthService -legacy');
+    expect(guarded.lexicalQueries).not.toContain('legacy auth migration');
+    expect(guarded.lexicalQueries).not.toContain('AuthService migration');
+    expect(guarded.vectorQueries).toEqual(['AuthService migration -legacy']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
+  test('requires quoted phrases rather than accepting partial phrase overlap', () => {
+    const guarded = applyExpansionGuardrails('debug "JWT token" parser', {
+      lexicalQueries: ['JWT parser', 'token parser'],
+      vectorQueries: ['JWT parser internals', 'debug JWT token parser'],
+      hyde: 'The parser handles JWT values but omits token phrase context.',
+    });
+
+    expect(guarded.lexicalQueries).toEqual(['"JWT token"']);
+    expect(guarded.vectorQueries).toEqual(['debug JWT token parser']);
+    expect(guarded.hyde).toBeUndefined();
+  });
+
+  test('preserves acronyms code symbols and critical entities exactly', () => {
+    const guarded = applyExpansionGuardrails('React.useEffect C++ JWT AuthService', {
+      lexicalQueries: ['react hooks authservice jwt', 'React.useEffect JWT'],
+      vectorQueries: [
+        'react hooks authservice jwt',
+        'React.useEffect C++ JWT AuthService lifecycle',
+      ],
+      hyde: 'React hooks discuss authservice jwt behavior without the exact code symbols.',
+    });
+
+    expect(guarded.lexicalQueries).toContain('React.useEffect C++ JWT AuthService');
+    expect(guarded.lexicalQueries).not.toContain('react hooks authservice jwt');
+    expect(guarded.vectorQueries).toEqual(['React.useEffect C++ JWT AuthService lifecycle']);
     expect(guarded.hyde).toBeUndefined();
   });
 
@@ -62,7 +104,7 @@ describe('query expansion parsing and guardrails', () => {
 });
 
 describe('query expansion routing', () => {
-  test('skips expansion for strong BM25 score and gap', async () => {
+  test('skips expansion for exact-name BM25 hits even with tiny FTS5 scores', async () => {
     expect(
       hasStrongBm25Signal([
         { name: 'authenticate', bm25Score: 0.95 },
@@ -80,14 +122,34 @@ describe('query expansion routing', () => {
         },
       },
       [
-        { name: 'authenticate', bm25Score: 0.95 },
-        { name: 'authMiddleware', bm25Score: 0.7 },
+        { name: 'authenticate', bm25Score: 0.000012 },
+        { name: 'authMiddleware', bm25Score: 0.000004 },
       ],
     );
 
     expect(routed.skipped).toBe('strong_bm25');
     expect(routed.bm25Queries).toEqual(['authenticate']);
     expect(routed.semanticQueries).toEqual(['authenticate']);
+  });
+
+  test('does not skip expansion for high non-exact BM25 scores alone', async () => {
+    const routed = await routeExpandedQueries(
+      'auth migration',
+      {
+        enabled: true,
+        provider: {
+          generate: async () =>
+            '{"lexicalQueries":["auth login"],"vectorQueries":["auth token validation"],"hyde":"auth migration token validation"}',
+        },
+      },
+      [
+        { name: 'authenticate', bm25Score: 0.95 },
+        { name: 'authMiddleware', bm25Score: 0.7 },
+      ],
+    );
+
+    expect(routed.skipped).toBeNull();
+    expect(routed.bm25Queries).toContain('auth login');
   });
 
   test('routes lexical variants only to BM25 and vector/HyDE variants only to semantic', async () => {

--- a/tests/search/fusion.test.ts
+++ b/tests/search/fusion.test.ts
@@ -8,7 +8,13 @@ describe('weighted RRF fusion', () => {
         { source: 'bm25_variant', query: 'variant', results: [{ key: 'variant-only', rank: 1 }] },
         { source: 'bm25', query: 'original', results: [{ key: 'original-only', rank: 1 }] },
       ],
-      { k: 60, weights: { bm25: 2, bm25_variant: 0.5 }, topRankBonus: 0, topRankThreshold: 3 },
+      {
+        k: 60,
+        weights: { bm25: 2, bm25_variant: 0.5 },
+        topRankBonus: 0,
+        topRankThreshold: 3,
+        nearTopRankBonusMultiplier: 0.4,
+      },
     );
 
     expect(top?.key).toBe('original-only');
@@ -21,19 +27,57 @@ describe('weighted RRF fusion', () => {
         { source: 'vector_variant', query: 'variant', results: [{ key: 'variant-top', rank: 1 }] },
         { source: 'bm25', query: 'original', results: [{ key: 'original-low', rank: 5 }] },
       ],
-      { k: 60, weights: { bm25: 1, vector_variant: 1 }, topRankBonus: 0, topRankThreshold: 3 },
+      {
+        k: 60,
+        weights: { bm25: 1, vector_variant: 1 },
+        topRankBonus: 0,
+        topRankThreshold: 3,
+        nearTopRankBonusMultiplier: 0.4,
+      },
     );
     const withBonus = weightedRrfFuse(
       [
         { source: 'vector_variant', query: 'variant', results: [{ key: 'variant-top', rank: 1 }] },
         { source: 'bm25', query: 'original', results: [{ key: 'original-low', rank: 5 }] },
       ],
-      { k: 60, weights: { bm25: 1, vector_variant: 1 }, topRankBonus: 0.1, topRankThreshold: 3 },
+      {
+        k: 60,
+        weights: { bm25: 1, vector_variant: 1 },
+        topRankBonus: 0.1,
+        topRankThreshold: 3,
+        nearTopRankBonusMultiplier: 0.4,
+      },
     );
 
     expect(withoutBonus[0]?.key).toBe('variant-top');
     expect(withBonus[0]?.score).toBeGreaterThan(withoutBonus[0]!.score);
     expect(withBonus[0]?.explain.topRankBonus).toBe(0.1);
+  });
+
+  test('uses configurable near-top rank bonus multiplier', () => {
+    const rankedLists = [
+      { source: 'bm25' as const, query: 'q', results: [{ key: 'near-top', rank: 3 }] },
+      { source: 'vector' as const, query: 'q', results: [{ key: 'lower', rank: 6 }] },
+    ];
+
+    const [defaultMultiplier] = weightedRrfFuse(rankedLists, {
+      k: 60,
+      weights: { bm25: 1, vector: 1 },
+      topRankBonus: 0.1,
+      topRankThreshold: 5,
+      nearTopRankBonusMultiplier: 0.4,
+    });
+    const [customMultiplier] = weightedRrfFuse(rankedLists, {
+      k: 60,
+      weights: { bm25: 1, vector: 1 },
+      topRankBonus: 0.1,
+      topRankThreshold: 5,
+      nearTopRankBonusMultiplier: 0.8,
+    });
+
+    expect(defaultMultiplier?.key).toBe('near-top');
+    expect(defaultMultiplier?.explain.topRankBonus).toBeCloseTo(0.04);
+    expect(customMultiplier?.explain.topRankBonus).toBeCloseTo(0.08);
   });
 
   test('uses deterministic tie ordering by stable key', () => {
@@ -42,7 +86,13 @@ describe('weighted RRF fusion', () => {
         { source: 'bm25', query: 'q', results: [{ key: 'b', rank: 1 }] },
         { source: 'vector', query: 'q', results: [{ key: 'a', rank: 1 }] },
       ],
-      { k: 60, weights: { bm25: 1, vector: 1 }, topRankBonus: 0, topRankThreshold: 3 },
+      {
+        k: 60,
+        weights: { bm25: 1, vector: 1 },
+        topRankBonus: 0,
+        topRankThreshold: 3,
+        nearTopRankBonusMultiplier: 0.4,
+      },
     );
 
     expect(fused.map((item) => item.key)).toEqual(['a', 'b']);
@@ -64,6 +114,7 @@ describe('weighted RRF fusion', () => {
         weights: { bm25: 2, vector_variant: 0.5, hyde: 0.7 },
         topRankBonus: 0,
         topRankThreshold: 3,
+        nearTopRankBonusMultiplier: 0.4,
       },
     );
 

--- a/tests/search/fusion.test.ts
+++ b/tests/search/fusion.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest';
+import { weightedRrfFuse } from '../../src/domain/search/search/fusion.js';
+
+describe('weighted RRF fusion', () => {
+  test('weights original sources more strongly than generated variants', () => {
+    const [top] = weightedRrfFuse(
+      [
+        { source: 'bm25_variant', query: 'variant', results: [{ key: 'variant-only', rank: 1 }] },
+        { source: 'bm25', query: 'original', results: [{ key: 'original-only', rank: 1 }] },
+      ],
+      { k: 60, weights: { bm25: 2, bm25_variant: 0.5 }, topRankBonus: 0, topRankThreshold: 3 },
+    );
+
+    expect(top?.key).toBe('original-only');
+    expect(top?.explain.sources[0]).toMatchObject({ source: 'bm25', weight: 2, rank: 1 });
+  });
+
+  test('applies configurable top-rank bonuses', () => {
+    const withoutBonus = weightedRrfFuse(
+      [
+        { source: 'vector_variant', query: 'variant', results: [{ key: 'variant-top', rank: 1 }] },
+        { source: 'bm25', query: 'original', results: [{ key: 'original-low', rank: 5 }] },
+      ],
+      { k: 60, weights: { bm25: 1, vector_variant: 1 }, topRankBonus: 0, topRankThreshold: 3 },
+    );
+    const withBonus = weightedRrfFuse(
+      [
+        { source: 'vector_variant', query: 'variant', results: [{ key: 'variant-top', rank: 1 }] },
+        { source: 'bm25', query: 'original', results: [{ key: 'original-low', rank: 5 }] },
+      ],
+      { k: 60, weights: { bm25: 1, vector_variant: 1 }, topRankBonus: 0.1, topRankThreshold: 3 },
+    );
+
+    expect(withoutBonus[0]?.key).toBe('variant-top');
+    expect(withBonus[0]?.score).toBeGreaterThan(withoutBonus[0]!.score);
+    expect(withBonus[0]?.explain.topRankBonus).toBe(0.1);
+  });
+
+  test('uses deterministic tie ordering by stable key', () => {
+    const fused = weightedRrfFuse(
+      [
+        { source: 'bm25', query: 'q', results: [{ key: 'b', rank: 1 }] },
+        { source: 'vector', query: 'q', results: [{ key: 'a', rank: 1 }] },
+      ],
+      { k: 60, weights: { bm25: 1, vector: 1 }, topRankBonus: 0, topRankThreshold: 3 },
+    );
+
+    expect(fused.map((item) => item.key)).toEqual(['a', 'b']);
+  });
+
+  test('tracks multi-query source contributions including HyDE weighting', () => {
+    const [candidate] = weightedRrfFuse(
+      [
+        { source: 'bm25', query: 'original', results: [{ key: 'shared', rank: 2 }] },
+        {
+          source: 'vector_variant',
+          query: 'semantic variant',
+          results: [{ key: 'shared', rank: 3 }],
+        },
+        { source: 'hyde', query: 'hypothetical passage', results: [{ key: 'shared', rank: 1 }] },
+      ],
+      {
+        k: 60,
+        weights: { bm25: 2, vector_variant: 0.5, hyde: 0.7 },
+        topRankBonus: 0,
+        topRankThreshold: 3,
+      },
+    );
+
+    expect(candidate?.explain.sources.map((source) => source.source)).toEqual([
+      'bm25',
+      'vector_variant',
+      'hyde',
+    ]);
+    expect(candidate?.explain.sources.find((source) => source.source === 'hyde')).toMatchObject({
+      query: 'hypothetical passage',
+      rank: 1,
+      weight: 0.7,
+    });
+  });
+});

--- a/tests/search/hybrid-expansion-routing.test.ts
+++ b/tests/search/hybrid-expansion-routing.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../src/db/index.js', () => ({
 }));
 
 vi.mock('../../src/infrastructure/config.js', () => ({
+  DEFAULTS: { search: { nearTopRankBonusMultiplier: 0.4 } },
   loadConfig: () => ({ search: { topK: 1, rrfK: 60 } }),
 }));
 

--- a/tests/search/hybrid-expansion-routing.test.ts
+++ b/tests/search/hybrid-expansion-routing.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ftsSearchData: vi.fn(),
+  searchData: vi.fn(),
+}));
+
+vi.mock('../../src/db/index.js', () => ({
+  openReadonlyOrFail: () => ({ close: vi.fn() }),
+}));
+
+vi.mock('../../src/infrastructure/config.js', () => ({
+  loadConfig: () => ({ search: { topK: 1, rrfK: 60 } }),
+}));
+
+vi.mock('../../src/domain/search/stores/fts5.js', () => ({
+  hasFtsIndex: () => true,
+}));
+
+vi.mock('../../src/domain/search/search/keyword.js', () => ({
+  ftsSearchData: mocks.ftsSearchData,
+}));
+
+vi.mock('../../src/domain/search/search/semantic.js', () => ({
+  searchData: mocks.searchData,
+}));
+
+const { hybridSearchData } = await import('../../src/domain/search/search/hybrid.js');
+
+describe('hybrid expansion routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ftsSearchData.mockReturnValue({
+      results: [
+        {
+          name: 'authenticate',
+          kind: 'function',
+          file: 'src/auth.ts',
+          line: 1,
+          endLine: null,
+          role: null,
+          fileHash: null,
+          bm25Score: 0.01,
+        },
+      ],
+    });
+    mocks.searchData.mockResolvedValue({ results: [] });
+  });
+
+  test('default-off expansion does not run an extra BM25 strong-signal probe', async () => {
+    await hybridSearchData('authenticate', 'codegraph.db', { limit: 1 });
+
+    expect(mocks.ftsSearchData).toHaveBeenCalledTimes(1);
+    expect(mocks.ftsSearchData).toHaveBeenCalledWith(
+      'authenticate',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+  });
+});

--- a/tests/search/hybrid-expansion-routing.test.ts
+++ b/tests/search/hybrid-expansion-routing.test.ts
@@ -57,4 +57,46 @@ describe('hybrid expansion routing', () => {
       expect.objectContaining({ limit: 5 }),
     );
   });
+
+  test('structured query modes bypass generation and route term separately from intent and hyde', async () => {
+    const provider = { generate: vi.fn(async () => '{}') };
+
+    await hybridSearchData('auth flow', 'codegraph.db', {
+      limit: 1,
+      expand: true,
+      expansionProvider: provider,
+      queryModes: [
+        { mode: 'term', text: '"refresh token"' },
+        { mode: 'intent', text: 'token rotation behavior' },
+        { mode: 'hyde', text: 'Refresh tokens rotate on each use.' },
+      ],
+    });
+
+    expect(provider.generate).not.toHaveBeenCalled();
+    expect(mocks.ftsSearchData).toHaveBeenCalledWith(
+      'auth flow',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+    expect(mocks.ftsSearchData).toHaveBeenCalledWith(
+      '"refresh token"',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+    expect(mocks.searchData).toHaveBeenCalledWith(
+      'auth flow',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+    expect(mocks.searchData).toHaveBeenCalledWith(
+      'token rotation behavior',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+    expect(mocks.searchData).toHaveBeenCalledWith(
+      'Refresh tokens rotate on each use.',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+  });
 });

--- a/tests/search/hybrid-expansion-routing.test.ts
+++ b/tests/search/hybrid-expansion-routing.test.ts
@@ -70,6 +70,7 @@ describe('hybrid expansion routing', () => {
         { mode: 'intent', text: 'token rotation behavior' },
         { mode: 'hyde', text: 'Refresh tokens rotate on each use.' },
       ],
+      queryTextKind: 'plain',
     });
 
     expect(provider.generate).not.toHaveBeenCalled();
@@ -98,5 +99,35 @@ describe('hybrid expansion routing', () => {
       'codegraph.db',
       expect.objectContaining({ limit: 5 }),
     );
+  });
+
+  test('derived intent query is not routed to BM25 and derived term query is not routed semantically', async () => {
+    await hybridSearchData('token rotation behavior', 'codegraph.db', {
+      limit: 1,
+      queryModes: [{ mode: 'intent', text: 'token rotation behavior' }],
+      queryTextKind: 'intent',
+    });
+
+    expect(mocks.ftsSearchData).not.toHaveBeenCalled();
+    expect(mocks.searchData).toHaveBeenCalledWith(
+      'token rotation behavior',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+
+    vi.clearAllMocks();
+
+    await hybridSearchData('"refresh token"', 'codegraph.db', {
+      limit: 1,
+      queryModes: [{ mode: 'term', text: '"refresh token"' }],
+      queryTextKind: 'term',
+    });
+
+    expect(mocks.ftsSearchData).toHaveBeenCalledWith(
+      '"refresh token"',
+      'codegraph.db',
+      expect.objectContaining({ limit: 5 }),
+    );
+    expect(mocks.searchData).not.toHaveBeenCalled();
   });
 });

--- a/tests/search/hybrid-rerank.test.ts
+++ b/tests/search/hybrid-rerank.test.ts
@@ -262,7 +262,7 @@ describe('hybrid search with reranking', () => {
     mocks.ftsSearchData.mockReturnValue({
       results: [
         bm25Result('alpha', 1, { content: 'fts content alpha' }),
-        bm25Result('beta', 0.9, { text_preview: 'preview beta' }),
+        bm25Result('beta', 0.9, { content: 'fts content beta', text_preview: 'preview beta' }),
         bm25Result('gamma', 0.8),
       ],
     });
@@ -287,7 +287,8 @@ describe('hybrid search with reranking', () => {
     });
 
     expect(capturedDocuments).toContain('full text alpha');
-    expect(capturedDocuments).toContain('preview beta');
+    expect(capturedDocuments).toContain('fts content beta');
+    expect(capturedDocuments).not.toContain('preview beta');
     expect(capturedDocuments).toContain('gamma (function) — src/gamma.ts:1');
   });
 

--- a/tests/search/hybrid-rerank.test.ts
+++ b/tests/search/hybrid-rerank.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   ftsSearchData: vi.fn(),
   searchData: vi.fn(),
+  resolveModelRoleUri: vi.fn(),
 }));
 
 vi.mock('../../src/db/index.js', () => ({
@@ -36,6 +37,10 @@ vi.mock('../../src/infrastructure/config.js', () => ({
   loadConfig: () => mockConfig,
 }));
 
+vi.mock('../../src/domain/search/models.js', () => ({
+  resolveModelRoleUri: mocks.resolveModelRoleUri,
+}));
+
 vi.mock('../../src/domain/search/stores/fts5.js', () => ({
   hasFtsIndex: () => true,
 }));
@@ -52,7 +57,7 @@ import type { RerankPort } from '../../src/domain/search/search/rerank.js';
 
 const { hybridSearchData } = await import('../../src/domain/search/search/hybrid.js');
 
-const bm25Result = (name: string, bm25Score = 1) => ({
+const bm25Result = (name: string, bm25Score = 1, extra: Record<string, unknown> = {}) => ({
   name,
   kind: 'function',
   file: `src/${name}.ts`,
@@ -61,9 +66,10 @@ const bm25Result = (name: string, bm25Score = 1) => ({
   role: null,
   fileHash: null,
   bm25Score,
+  ...extra,
 });
 
-const vectorResult = (name: string, similarity = 0.9) => ({
+const vectorResult = (name: string, similarity = 0.9, extra: Record<string, unknown> = {}) => ({
   name,
   kind: 'function',
   file: `src/${name}.ts`,
@@ -72,11 +78,13 @@ const vectorResult = (name: string, similarity = 0.9) => ({
   role: null,
   fileHash: null,
   similarity,
+  ...extra,
 });
 
 describe('hybrid search with reranking', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveModelRoleUri.mockReturnValue('local:unsupported-reranker');
   });
 
   test('skips reranking when rerankPort is not provided', async () => {
@@ -151,6 +159,138 @@ describe('hybrid search with reranking', () => {
     }
   });
 
+  test('uses successful rerank output to drive final result ordering', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha'), bm25Result('beta')] });
+    mocks.searchData.mockResolvedValue({ results: [] });
+
+    const mockPort: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: i === 0 ? 0.1 : 0.99 })),
+        };
+      },
+    };
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: {
+        ...mockConfig,
+        search: {
+          ...mockConfig.search,
+          rerank: { ...mockConfig.search.rerank, rerankWeight: 1, fusionWeight: 0 },
+        },
+      } as any,
+      rerankPort: mockPort,
+      explain: true,
+    });
+
+    expect(data?.results.map((r) => r.name)).toEqual(['beta', 'alpha']);
+    expect(data?.results[0]?.bm25Rank).toBe(2);
+    expect(data?.results[0]?.rrf).toBeGreaterThan(0);
+  });
+
+  test('creates an HTTP rerank port from configured rerank model role when no port is injected', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha'), bm25Result('beta')] });
+    mocks.searchData.mockResolvedValue({ results: [] });
+    mocks.resolveModelRoleUri.mockReturnValue('https://reranker.example.test/rerank');
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { index: 0, score: 0.2 },
+            { index: 1, score: 0.9 },
+          ]),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: {
+        ...mockConfig,
+        search: {
+          ...mockConfig.search,
+          rerank: { ...mockConfig.search.rerank, rerankWeight: 1, fusionWeight: 0 },
+        },
+      } as any,
+      explain: true,
+    });
+
+    expect(mocks.resolveModelRoleUri).toHaveBeenCalledWith(expect.any(Object), 'rerank');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://reranker.example.test/rerank',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(data?.results.map((r) => r.name)).toEqual(['beta', 'alpha']);
+
+    vi.unstubAllGlobals();
+  });
+
+  test('protects the original plain BM25 top hit from rerank demotion at hybrid level', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha'), bm25Result('beta')] });
+    mocks.searchData.mockResolvedValue({ results: [] });
+
+    const mockPort: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: i === 0 ? 0.1 : 0.99 })),
+        };
+      },
+    };
+
+    const data = await hybridSearchData('alpha', 'codegraph.db', {
+      config: {
+        ...mockConfig,
+        search: {
+          ...mockConfig.search,
+          rerank: { ...mockConfig.search.rerank, rerankWeight: 1, fusionWeight: 0 },
+        },
+      } as any,
+      rerankPort: mockPort,
+      explain: true,
+    });
+
+    expect(data?.results.map((r) => r.name)).toEqual(['alpha', 'beta']);
+    expect(data?.results[0]?.rerank?.rerankExplain?.protectedLexicalHit).toBe(true);
+  });
+
+  test('passes best available symbol text to rerank port', async () => {
+    mocks.ftsSearchData.mockReturnValue({
+      results: [
+        bm25Result('alpha', 1, { content: 'fts content alpha' }),
+        bm25Result('beta', 0.9, { text_preview: 'preview beta' }),
+        bm25Result('gamma', 0.8),
+      ],
+    });
+    mocks.searchData.mockResolvedValue({
+      results: [vectorResult('alpha', 0.9, { full_text: 'full text alpha' })],
+    });
+    let capturedDocuments: string[] = [];
+    const mockPort: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        capturedDocuments = documents;
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: 1 - i / 10 })),
+        };
+      },
+    };
+
+    await hybridSearchData('test query', 'codegraph.db', {
+      config: mockConfig as any,
+      rerankPort: mockPort,
+      explain: true,
+    });
+
+    expect(capturedDocuments).toContain('full text alpha');
+    expect(capturedDocuments).toContain('preview beta');
+    expect(capturedDocuments).toContain('gamma (function) — src/gamma.ts:1');
+  });
+
   test('gracefully handles rerank port failure', async () => {
     mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
     mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
@@ -170,5 +310,7 @@ describe('hybrid search with reranking', () => {
     // Should still return fusion results (fallback)
     expect(data?.results).toBeDefined();
     expect(data!.results.length).toBeGreaterThan(0);
+    expect(data!.results[0]?.rerank?.rerankExplain?.fallbackCode).toBe('port_error');
+    expect(data!.results[0]?.rerank?.rerankExplain?.fallbackMessage).toBe('model crashed');
   });
 });

--- a/tests/search/hybrid-rerank.test.ts
+++ b/tests/search/hybrid-rerank.test.ts
@@ -103,7 +103,7 @@ describe('hybrid search with reranking', () => {
     }
   });
 
-  test('skips reranking when rerank is disabled in config', async () => {
+  test('skips reranking by default when rerank is disabled in config', async () => {
     mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
     mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
 
@@ -120,6 +120,57 @@ describe('hybrid search with reranking', () => {
 
     const data = await hybridSearchData('test query', 'codegraph.db', {
       config: disabledConfig as any,
+      rerankPort: mockPort,
+      explain: true,
+    });
+
+    expect(data?.results).toBeDefined();
+    for (const r of data?.results ?? []) {
+      expect(r.rerank).toBeUndefined();
+    }
+  });
+
+  test('allows request-level rerank true to enable reranking when config default is disabled', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
+    mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
+
+    const disabledConfig = {
+      ...mockConfig,
+      search: { ...mockConfig.search, rerank: { ...mockConfig.search.rerank, enabled: false } },
+    };
+
+    const mockPort: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: 0.5 })),
+        };
+      },
+    };
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: disabledConfig as any,
+      rerank: true,
+      rerankPort: mockPort,
+      explain: true,
+    });
+
+    expect(data?.results.some((r) => r.rerank !== undefined)).toBe(true);
+  });
+
+  test('allows request-level rerank false to disable reranking when config default is enabled', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
+    mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
+
+    const mockPort: RerankPort = {
+      async rerank() {
+        throw new Error('should not be called');
+      },
+    };
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: mockConfig as any,
+      rerank: false,
       rerankPort: mockPort,
       explain: true,
     });

--- a/tests/search/hybrid-rerank.test.ts
+++ b/tests/search/hybrid-rerank.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ftsSearchData: vi.fn(),
+  searchData: vi.fn(),
+}));
+
+vi.mock('../../src/db/index.js', () => ({
+  openReadonlyOrFail: () => ({ close: vi.fn() }),
+}));
+
+const mockConfig = {
+  search: {
+    topK: 5,
+    rrfK: 60,
+    rrfWeights: { bm25: 2, bm25Variant: 0.5, vector: 2, vectorVariant: 0.5, hyde: 0.7 },
+    topRankBonus: 0,
+    topRankThreshold: 3,
+    nearTopRankBonusMultiplier: 0.4,
+    rerank: {
+      enabled: true,
+      maxCandidates: 10,
+      fusionWeight: 0.4,
+      rerankWeight: 0.6,
+    },
+  },
+};
+
+vi.mock('../../src/infrastructure/config.js', () => ({
+  DEFAULTS: {
+    search: {
+      nearTopRankBonusMultiplier: 0.4,
+      rerank: { enabled: false, maxCandidates: 20, fusionWeight: 0.4, rerankWeight: 0.6 },
+    },
+  },
+  loadConfig: () => mockConfig,
+}));
+
+vi.mock('../../src/domain/search/stores/fts5.js', () => ({
+  hasFtsIndex: () => true,
+}));
+
+vi.mock('../../src/domain/search/search/keyword.js', () => ({
+  ftsSearchData: mocks.ftsSearchData,
+}));
+
+vi.mock('../../src/domain/search/search/semantic.js', () => ({
+  searchData: mocks.searchData,
+}));
+
+import type { RerankPort } from '../../src/domain/search/search/rerank.js';
+
+const { hybridSearchData } = await import('../../src/domain/search/search/hybrid.js');
+
+const bm25Result = (name: string, bm25Score = 1) => ({
+  name,
+  kind: 'function',
+  file: `src/${name}.ts`,
+  line: 1,
+  endLine: null,
+  role: null,
+  fileHash: null,
+  bm25Score,
+});
+
+const vectorResult = (name: string, similarity = 0.9) => ({
+  name,
+  kind: 'function',
+  file: `src/${name}.ts`,
+  line: 1,
+  endLine: null,
+  role: null,
+  fileHash: null,
+  similarity,
+});
+
+describe('hybrid search with reranking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('skips reranking when rerankPort is not provided', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
+    mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: mockConfig as any,
+      explain: true,
+    });
+
+    expect(data?.results).toBeDefined();
+    // No rerank metadata should be present
+    for (const r of data?.results ?? []) {
+      expect(r.rerank).toBeUndefined();
+    }
+  });
+
+  test('skips reranking when rerank is disabled in config', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
+    mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
+
+    const disabledConfig = {
+      ...mockConfig,
+      search: { ...mockConfig.search, rerank: { ...mockConfig.search.rerank, enabled: false } },
+    };
+
+    const mockPort: RerankPort = {
+      async rerank() {
+        throw new Error('should not be called');
+      },
+    };
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: disabledConfig as any,
+      rerankPort: mockPort,
+      explain: true,
+    });
+
+    expect(data?.results).toBeDefined();
+    for (const r of data?.results ?? []) {
+      expect(r.rerank).toBeUndefined();
+    }
+  });
+
+  test('applies reranking when port is provided and config enabled', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
+    mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
+
+    const mockPort: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: 0.5 })),
+        };
+      },
+    };
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: mockConfig as any,
+      rerankPort: mockPort,
+      explain: true,
+    });
+
+    expect(data?.results).toBeDefined();
+    // At least some results should have rerank metadata
+    const withRerank = data?.results.filter((r) => r.rerank !== undefined) ?? [];
+    expect(withRerank.length).toBeGreaterThan(0);
+    for (const r of withRerank) {
+      expect(r.rerank?.rerankScore).not.toBeNull();
+      expect(r.rerank?.blendedScore).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test('gracefully handles rerank port failure', async () => {
+    mocks.ftsSearchData.mockReturnValue({ results: [bm25Result('alpha')] });
+    mocks.searchData.mockResolvedValue({ results: [vectorResult('beta')] });
+
+    const failingPort: RerankPort = {
+      async rerank() {
+        return { ok: false as const, error: new Error('model crashed') };
+      },
+    };
+
+    const data = await hybridSearchData('test query', 'codegraph.db', {
+      config: mockConfig as any,
+      rerankPort: failingPort,
+      explain: true,
+    });
+
+    // Should still return fusion results (fallback)
+    expect(data?.results).toBeDefined();
+    expect(data!.results.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/search/hybrid-weighted-rrf.test.ts
+++ b/tests/search/hybrid-weighted-rrf.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../src/db/index.js', () => ({
 }));
 
 vi.mock('../../src/infrastructure/config.js', () => ({
+  DEFAULTS: { search: { nearTopRankBonusMultiplier: 0.4 } },
   loadConfig: () => ({
     search: {
       topK: 2,
@@ -17,6 +18,7 @@ vi.mock('../../src/infrastructure/config.js', () => ({
       rrfWeights: { bm25: 2, bm25Variant: 0.5, vector: 2, vectorVariant: 0.5, hyde: 0.7 },
       topRankBonus: 0,
       topRankThreshold: 3,
+      nearTopRankBonusMultiplier: 0.4,
     },
   }),
 }));

--- a/tests/search/hybrid-weighted-rrf.test.ts
+++ b/tests/search/hybrid-weighted-rrf.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ftsSearchData: vi.fn(),
+  searchData: vi.fn(),
+}));
+
+vi.mock('../../src/db/index.js', () => ({
+  openReadonlyOrFail: () => ({ close: vi.fn() }),
+}));
+
+vi.mock('../../src/infrastructure/config.js', () => ({
+  loadConfig: () => ({
+    search: {
+      topK: 2,
+      rrfK: 60,
+      rrfWeights: { bm25: 2, bm25Variant: 0.5, vector: 2, vectorVariant: 0.5, hyde: 0.7 },
+      topRankBonus: 0,
+      topRankThreshold: 3,
+    },
+  }),
+}));
+
+vi.mock('../../src/domain/search/stores/fts5.js', () => ({
+  hasFtsIndex: () => true,
+}));
+
+vi.mock('../../src/domain/search/search/keyword.js', () => ({
+  ftsSearchData: mocks.ftsSearchData,
+}));
+
+vi.mock('../../src/domain/search/search/semantic.js', () => ({
+  searchData: mocks.searchData,
+}));
+
+const { hybridSearchData } = await import('../../src/domain/search/search/hybrid.js');
+
+const bm25Result = (name: string, bm25Score = 1) => ({
+  name,
+  kind: 'function',
+  file: `src/${name}.ts`,
+  line: 1,
+  endLine: null,
+  role: null,
+  fileHash: null,
+  bm25Score,
+});
+
+const vectorResult = (name: string, similarity = 0.9) => ({
+  name,
+  kind: 'function',
+  file: `src/${name}.ts`,
+  line: 1,
+  endLine: null,
+  role: null,
+  fileHash: null,
+  similarity,
+});
+
+describe('hybrid weighted RRF', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('fuses expanded BM25/vector sources with explainable source metadata', async () => {
+    const provider = {
+      generate: vi.fn(async () =>
+        JSON.stringify({
+          lexicalQueries: ['auth token'],
+          vectorQueries: ['authentication token flow'],
+          hyde: 'Authentication token flow code validates and rotates credentials.',
+        }),
+      ),
+    };
+    mocks.ftsSearchData
+      .mockReturnValueOnce({ results: [] })
+      .mockReturnValueOnce({ results: [bm25Result('original')] })
+      .mockReturnValueOnce({ results: [bm25Result('variant')] });
+    mocks.searchData
+      .mockResolvedValueOnce({ results: [vectorResult('semantic')] })
+      .mockResolvedValueOnce({ results: [vectorResult('variant')] })
+      .mockResolvedValueOnce({ results: [vectorResult('hyde')] });
+
+    const data = await hybridSearchData('auth token flow', 'codegraph.db', {
+      limit: 5,
+      expand: true,
+      expansionProvider: provider,
+      explain: true,
+    });
+
+    expect(data?.results.map((result) => result.name)).toEqual([
+      'original',
+      'semantic',
+      'variant',
+      'hyde',
+    ]);
+    expect(data?.results[0]?.explain?.sources[0]).toMatchObject({
+      source: 'bm25',
+      stage: 'bm25',
+      rank: 1,
+      weight: 2,
+    });
+    expect(
+      data?.results.find((result) => result.name === 'hyde')?.explain?.sources[0],
+    ).toMatchObject({
+      source: 'hyde',
+      stage: 'vector',
+      weight: 0.7,
+    });
+  });
+});

--- a/tests/search/model-presets.test.ts
+++ b/tests/search/model-presets.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MODEL,
   DEFAULT_RETRIEVAL_PRESET,
   MODELS,
+  RETRIEVAL_MODEL_PRESETS,
   resolveModelRoleUri,
   resolveRetrievalModels,
 } from '../../src/domain/search/index.js';
@@ -27,6 +28,18 @@ describe('retrieval model role resolution', () => {
     expect(resolved.roles.rerank).toContain('Reranker');
     expect(resolved.roles.expand).toContain('Qwen');
     expect(resolved.roles.gen).toContain('Qwen');
+  });
+
+  test('resolves non-default preset embed role with merged default config shape', () => {
+    const resolved = resolveRetrievalModels({
+      ...(DEFAULTS as CodegraphConfig),
+      embeddings: { ...DEFAULTS.embeddings },
+      models: { ...DEFAULTS.models, preset: 'gno-compact' },
+    });
+
+    expect(resolved.preset).toBe('gno-compact');
+    expect(resolved.roles.embed).toBe(RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed);
+    expect(resolved.roles.embed).not.toBe(MODELS[DEFAULT_MODEL]!.name);
   });
 
   test('applies config role overrides on top of the selected built-in preset', () => {

--- a/tests/search/model-presets.test.ts
+++ b/tests/search/model-presets.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+import {
+  DEFAULT_MODEL,
+  DEFAULT_RETRIEVAL_PRESET,
+  MODELS,
+  resolveModelRoleUri,
+  resolveRetrievalModels,
+} from '../../src/domain/search/index.js';
+import { DEFAULTS } from '../../src/infrastructure/config.js';
+import type { CodegraphConfig } from '../../src/types.js';
+
+function config(overrides: Partial<CodegraphConfig> = {}): CodegraphConfig {
+  return {
+    ...(DEFAULTS as CodegraphConfig),
+    ...overrides,
+    embeddings: { ...DEFAULTS.embeddings, ...overrides.embeddings },
+    models: overrides.models,
+  } as CodegraphConfig;
+}
+
+describe('retrieval model role resolution', () => {
+  test('resolves every role from the default preset without changing the legacy embed default', () => {
+    const resolved = resolveRetrievalModels(config());
+
+    expect(resolved.preset).toBe(DEFAULT_RETRIEVAL_PRESET);
+    expect(resolved.roles.embed).toBe(MODELS[DEFAULT_MODEL]!.name);
+    expect(resolved.roles.rerank).toContain('Reranker');
+    expect(resolved.roles.expand).toContain('Qwen');
+    expect(resolved.roles.gen).toContain('Qwen');
+  });
+
+  test('applies config role overrides on top of the selected built-in preset', () => {
+    const resolved = resolveRetrievalModels(
+      config({
+        models: {
+          preset: 'gno-compact',
+          roles: {
+            embed: 'hf:custom/embed-model',
+            rerank: 'http://localhost:8080/rerank',
+          },
+        },
+      }),
+    );
+
+    expect(resolved.preset).toBe('gno-compact');
+    expect(resolved.roles.embed).toBe('hf:custom/embed-model');
+    expect(resolved.roles.rerank).toBe('http://localhost:8080/rerank');
+    expect(resolved.roles.expand).toBeTruthy();
+    expect(resolved.roles.gen).toBeTruthy();
+  });
+
+  test('falls back to the default preset when config names an invalid preset', () => {
+    const resolved = resolveRetrievalModels(config({ models: { preset: 'not-real' } }));
+
+    expect(resolved.preset).toBe(DEFAULT_RETRIEVAL_PRESET);
+    expect(resolved.requestedPreset).toBe('not-real');
+    expect(resolved.roles.embed).toBe(MODELS[DEFAULT_MODEL]!.name);
+  });
+
+  test('uses legacy embeddings.model as the embed role compatibility layer', () => {
+    const resolved = resolveRetrievalModels(
+      config({ embeddings: { model: 'minilm', llmProvider: null } }),
+    );
+
+    expect(resolved.roles.embed).toBe(MODELS.minilm!.name);
+    expect(
+      resolveModelRoleUri(config({ embeddings: { model: 'minilm', llmProvider: null } }), 'embed'),
+    ).toBe(MODELS.minilm!.name);
+  });
+});

--- a/tests/search/model-presets.test.ts
+++ b/tests/search/model-presets.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
 import {
+  DEFAULT_EMBEDDING_MODEL,
   DEFAULT_MODEL,
   DEFAULT_RETRIEVAL_PRESET,
+  LEGACY_TRANSFORMER_DEFAULT_MODEL,
   MODELS,
   RETRIEVAL_MODEL_PRESETS,
   resolveModelRoleUri,
@@ -20,26 +22,52 @@ function config(overrides: Partial<CodegraphConfig> = {}): CodegraphConfig {
 }
 
 describe('retrieval model role resolution', () => {
-  test('resolves every role from the default preset without changing the legacy embed default', () => {
+  test('resolves every role from the GNO compact default preset', () => {
     const resolved = resolveRetrievalModels(config());
 
-    expect(resolved.preset).toBe(DEFAULT_RETRIEVAL_PRESET);
-    expect(resolved.roles.embed).toBe(MODELS[DEFAULT_MODEL]!.name);
+    expect(DEFAULT_RETRIEVAL_PRESET).toBe('gno-compact');
+    expect(DEFAULT_MODEL).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(resolved.preset).toBe('gno-compact');
+    expect(resolved.roles.embed).toBe(DEFAULT_EMBEDDING_MODEL);
     expect(resolved.roles.rerank).toContain('Reranker');
     expect(resolved.roles.expand).toContain('Qwen');
     expect(resolved.roles.gen).toContain('Qwen');
+  });
+
+  test('keeps codegraph-default available as a legacy compatibility preset', () => {
+    const resolved = resolveRetrievalModels({
+      ...(DEFAULTS as CodegraphConfig),
+      embeddings: { ...DEFAULTS.embeddings },
+      models: { ...DEFAULTS.models, preset: 'codegraph-default' },
+    });
+
+    expect(resolved.preset).toBe('codegraph-default');
+    expect(resolved.roles.embed).toBe(MODELS[LEGACY_TRANSFORMER_DEFAULT_MODEL]!.name);
+    expect(resolved.roles.embed).not.toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  test('explicit legacy embeddings.model still overrides the legacy compatibility preset', () => {
+    const resolved = resolveRetrievalModels(
+      config({
+        embeddings: { model: 'minilm', llmProvider: null },
+        models: { preset: 'codegraph-default' },
+      }),
+    );
+
+    expect(resolved.preset).toBe('codegraph-default');
+    expect(resolved.roles.embed).toBe(MODELS.minilm!.name);
   });
 
   test('resolves non-default preset embed role with merged default config shape', () => {
     const resolved = resolveRetrievalModels({
       ...(DEFAULTS as CodegraphConfig),
       embeddings: { ...DEFAULTS.embeddings },
-      models: { ...DEFAULTS.models, preset: 'gno-compact' },
+      models: { ...DEFAULTS.models, preset: 'gno-balanced' },
     });
 
-    expect(resolved.preset).toBe('gno-compact');
-    expect(resolved.roles.embed).toBe(RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed);
-    expect(resolved.roles.embed).not.toBe(MODELS[DEFAULT_MODEL]!.name);
+    expect(resolved.preset).toBe('gno-balanced');
+    expect(resolved.roles.embed).toBe(RETRIEVAL_MODEL_PRESETS['gno-balanced']!.roles.embed);
+    expect(resolved.roles.embed).not.toBe(MODELS[LEGACY_TRANSFORMER_DEFAULT_MODEL]!.name);
   });
 
   test('applies config role overrides on top of the selected built-in preset', () => {
@@ -67,17 +95,20 @@ describe('retrieval model role resolution', () => {
 
     expect(resolved.preset).toBe(DEFAULT_RETRIEVAL_PRESET);
     expect(resolved.requestedPreset).toBe('not-real');
-    expect(resolved.roles.embed).toBe(MODELS[DEFAULT_MODEL]!.name);
+    expect(resolved.roles.embed).toBe(DEFAULT_EMBEDDING_MODEL);
   });
 
-  test('uses legacy embeddings.model as the embed role compatibility layer', () => {
+  test('explicit legacy embeddings.model overrides the default embed role compatibility layer', () => {
     const resolved = resolveRetrievalModels(
-      config({ embeddings: { model: 'minilm', llmProvider: null } }),
+      config({ embeddings: { model: 'nomic-v1.5', llmProvider: null } }),
     );
 
-    expect(resolved.roles.embed).toBe(MODELS.minilm!.name);
+    expect(resolved.roles.embed).toBe(MODELS['nomic-v1.5']!.name);
     expect(
-      resolveModelRoleUri(config({ embeddings: { model: 'minilm', llmProvider: null } }), 'embed'),
-    ).toBe(MODELS.minilm!.name);
+      resolveModelRoleUri(
+        config({ embeddings: { model: 'nomic-v1.5', llmProvider: null } }),
+        'embed',
+      ),
+    ).toBe(MODELS['nomic-v1.5']!.name);
   });
 });

--- a/tests/search/models-command.test.ts
+++ b/tests/search/models-command.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { command } from '../../src/cli/commands/models.js';
+import type { CliContext } from '../../src/cli/types.js';
+import { DEFAULTS } from '../../src/infrastructure/config.js';
+import type { CodegraphConfig } from '../../src/types.js';
+
+function ctx(config: Partial<CodegraphConfig> = {}): CliContext {
+  return {
+    config: {
+      ...(DEFAULTS as CodegraphConfig),
+      ...config,
+      embeddings: { ...DEFAULTS.embeddings, ...config.embeddings },
+    } as CodegraphConfig,
+    resolveNoTests: () => false,
+    resolveQueryOpts: (opts) => opts,
+    formatSize: (bytes) => `${bytes}B`,
+    outputResult: () => false,
+    program: {} as CliContext['program'],
+  };
+}
+
+describe('models command defaults', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('marks the resolved embed role instead of stale embeddings.model', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    command.execute?.(
+      [],
+      {},
+      ctx({
+        embeddings: { model: 'minilm', llmProvider: null },
+        models: { preset: 'gno-balanced' },
+      }),
+    );
+
+    const output = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(output).toContain(
+      'Default embedding role: hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+    );
+    expect(output).not.toMatch(/minilm.*\(default\)/);
+  });
+});

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   createEmbeddingPort,
   formatEmbeddingDocument,
@@ -17,9 +17,17 @@ import {
 
 function ggufFile(dir: string, name = 'model.gguf'): string {
   const file = path.join(dir, name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, Buffer.from([0x47, 0x47, 0x55, 0x46, 0, 0]));
   return file;
 }
+
+const originalHome = process.env.HOME;
+const originalNoAutoDownload = process.env.CODEGRAPH_NO_AUTO_DOWNLOAD;
+afterEach(() => {
+  process.env.HOME = originalHome;
+  process.env.CODEGRAPH_NO_AUTO_DOWNLOAD = originalNoAutoDownload;
+});
 
 describe('Qwen embedding compatibility formatting', () => {
   test('formats Qwen queries with instruct-style prompt and keeps documents raw', () => {
@@ -209,6 +217,26 @@ describe('HTTP embedding port', () => {
 });
 
 describe('embedding port factory', () => {
+  test('public embed() without an explicit model reaches the GGUF-capable default path', async () => {
+    vi.resetModules();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-public-embed-'));
+    process.env.HOME = tmp;
+    process.env.CODEGRAPH_NO_AUTO_DOWNLOAD = '1';
+    try {
+      const { DEFAULT_EMBEDDING_MODEL, embed } = await import('../../src/domain/search/index.js');
+      expect(DEFAULT_EMBEDDING_MODEL).toBe(
+        'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      );
+
+      await expect(embed(['x'], undefined)).rejects.toThrow(
+        /automatic downloads are disabled|not cached/i,
+      );
+      await expect(embed(['x'], undefined)).rejects.not.toThrow(/Unknown model/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('creates the built-in GNO compact Qwen embed preset through the GGUF cache path', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-preset-cache-'));
     try {

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   createEmbeddingPort,
+  DEFAULT_MODEL,
+  embed,
   formatEmbeddingDocument,
   formatEmbeddingQuery,
   HttpEmbeddingPort,
@@ -217,6 +219,35 @@ describe('HTTP embedding port', () => {
 });
 
 describe('embedding port factory', () => {
+  test('public embed() with the explicit default model reaches the GGUF-capable path', async () => {
+    vi.resetModules();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-public-explicit-embed-'));
+    process.env.HOME = tmp;
+    process.env.CODEGRAPH_NO_AUTO_DOWNLOAD = '1';
+    try {
+      await expect(embed(['x'], DEFAULT_MODEL)).rejects.toThrow(
+        /automatic downloads are disabled|not cached/i,
+      );
+      await expect(embed(['x'], DEFAULT_MODEL)).rejects.not.toThrow(/Unknown model/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('public embed() routes explicit HTTP embedding URIs through the factory', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ index: 0, embedding: [0.25, 0.75] }] }),
+    } as Response);
+    try {
+      const result = await embed(['hello'], 'http://localhost:8000/v1/embeddings#qwen');
+      expect(result.dim).toBe(2);
+      expect(result.vectors.map((vector) => Array.from(vector))).toEqual([[0.25, 0.75]]);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   test('public embed() without an explicit model reaches the GGUF-capable default path', async () => {
     vi.resetModules();
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-public-embed-'));

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -26,9 +26,18 @@ function ggufFile(dir: string, name = 'model.gguf'): string {
 
 const originalHome = process.env.HOME;
 const originalNoAutoDownload = process.env.CODEGRAPH_NO_AUTO_DOWNLOAD;
+
+function restoreEnv(name: 'HOME' | 'CODEGRAPH_NO_AUTO_DOWNLOAD', value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
 afterEach(() => {
-  process.env.HOME = originalHome;
-  process.env.CODEGRAPH_NO_AUTO_DOWNLOAD = originalNoAutoDownload;
+  restoreEnv('HOME', originalHome);
+  restoreEnv('CODEGRAPH_NO_AUTO_DOWNLOAD', originalNoAutoDownload);
 });
 
 describe('Qwen embedding compatibility formatting', () => {

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -119,6 +119,50 @@ describe('model URI parsing, GGUF validation, and download policy', () => {
     }
   });
 
+  test('surfaces validation errors for invalid deterministic cached GGUF files', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-cache-invalid-local-'));
+    try {
+      const uri = 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf';
+      const file = path.join(tmp, 'Qwen', 'Qwen3-Embedding-0.6B-GGUF', 'model.gguf');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, '<html>huggingface login</html>');
+
+      await expect(
+        new ModelCache(tmp).ensureModel(uri, 'embed', { offline: true, allowDownload: false }),
+      ).rejects.toThrow(/looks like HTML instead of GGUF/i);
+      await expect(
+        new ModelCache(tmp).ensureModel(uri, 'embed', { offline: true, allowDownload: false }),
+      ).rejects.not.toThrow(/not cached/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('surfaces validation errors for invalid manifest cache entries', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-cache-invalid-manifest-'));
+    try {
+      const uri = 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf';
+      const file = path.join(tmp, 'bad.gguf');
+      fs.writeFileSync(file, 'corrupt');
+      fs.writeFileSync(
+        path.join(tmp, 'manifest.json'),
+        JSON.stringify({
+          version: '1.0',
+          models: [{ uri, type: 'embed', path: file, cachedAt: new Date().toISOString() }],
+        }),
+      );
+
+      await expect(
+        new ModelCache(tmp).ensureModel(uri, 'embed', { offline: true, allowDownload: false }),
+      ).rejects.toThrow(/missing GGUF magic header/i);
+      await expect(
+        new ModelCache(tmp).ensureModel(uri, 'embed', { offline: true, allowDownload: false }),
+      ).rejects.not.toThrow(/not cached/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('resolves policy from env with offline taking precedence', () => {
     expect(resolveDownloadPolicy({ HF_HUB_OFFLINE: '1', CODEGRAPH_NO_AUTO_DOWNLOAD: '1' })).toEqual(
       {

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -9,7 +9,9 @@ import {
   HttpEmbeddingPort,
   ModelCache,
   parseModelUri,
+  RETRIEVAL_MODEL_PRESETS,
   resolveDownloadPolicy,
+  resolveModelRoleUri,
   validateGgufFile,
 } from '../../src/domain/search/index.js';
 
@@ -37,6 +39,16 @@ describe('Qwen embedding compatibility formatting', () => {
 });
 
 describe('model URI parsing, GGUF validation, and download policy', () => {
+  test('built-in GNO-inspired preset role URIs use explicit GGUF filenames', () => {
+    for (const presetName of ['gno-compact', 'gno-balanced', 'gno-quality'] as const) {
+      const preset = RETRIEVAL_MODEL_PRESETS[presetName]!;
+      for (const uri of Object.values(preset.roles)) {
+        expect(uri).toMatch(/^hf:.+\.gguf$/);
+        expect(parseModelUri(uri)).toMatchObject({ scheme: 'hf' });
+      }
+    }
+  });
+
   test('parses hf explicit GGUF, hf quant shorthand, file URLs, and absolute paths', () => {
     expect(parseModelUri('hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf')).toEqual({
       scheme: 'hf',
@@ -79,13 +91,29 @@ describe('model URI parsing, GGUF validation, and download policy', () => {
           offline: true,
           allowDownload: false,
         }),
-      ).rejects.toThrow(/offline mode/i);
+      ).rejects.toThrow(/offline mode.*manifest/i);
       await expect(
         cache.ensureModel('hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf', 'embed', {
           offline: false,
           allowDownload: false,
         }),
-      ).rejects.toThrow(/automatic downloads are disabled/i);
+      ).rejects.toThrow(/automatic downloads are disabled.*manifest/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('discovers explicit HuggingFace GGUF files in the cache directory without a manifest', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-cache-local-'));
+    try {
+      const uri = 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf';
+      const file = path.join(tmp, 'Qwen', 'Qwen3-Embedding-0.6B-GGUF', 'model.gguf');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, Buffer.from([0x47, 0x47, 0x55, 0x46, 0, 0]));
+
+      await expect(
+        new ModelCache(tmp).ensureModel(uri, 'embed', { offline: true, allowDownload: false }),
+      ).resolves.toBe(file);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -137,6 +165,43 @@ describe('HTTP embedding port', () => {
 });
 
 describe('embedding port factory', () => {
+  test('creates the built-in GNO compact Qwen embed preset through the GGUF cache path', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-preset-cache-'));
+    try {
+      const uri = resolveModelRoleUri({ models: { preset: 'gno-compact' } }, 'embed');
+      expect(uri).toBe('hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf');
+      expect(uri).toBe(RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed);
+
+      const file = ggufFile(tmp, 'Qwen3-Embedding-0.6B-Q8_0.gguf');
+      fs.writeFileSync(
+        path.join(tmp, 'manifest.json'),
+        JSON.stringify({
+          version: '1.0',
+          models: [{ uri, type: 'embed', path: file, cachedAt: new Date().toISOString() }],
+        }),
+      );
+      const runtimeLoader = vi.fn(async () => ({
+        getLlama: async () => ({
+          loadModel: async () => ({
+            createEmbeddingContext: async () => ({
+              getEmbeddingFor: async () => ({ vector: [3, 4] }),
+            }),
+          }),
+        }),
+      }));
+
+      const port = await createEmbeddingPort(uri, {
+        cacheDir: tmp,
+        inputType: 'document',
+        runtimeLoader,
+      });
+      const [vector] = await port.embedBatch(['function route() {}']);
+      expect(Array.from(vector!)).toEqual([3, 4]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('creates Qwen GGUF port from local file without requiring node-llama-cpp until used', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-factory-'));
     try {

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -1,0 +1,183 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
+import {
+  createEmbeddingPort,
+  formatEmbeddingDocument,
+  formatEmbeddingQuery,
+  HttpEmbeddingPort,
+  ModelCache,
+  parseModelUri,
+  resolveDownloadPolicy,
+  validateGgufFile,
+} from '../../src/domain/search/index.js';
+
+function ggufFile(dir: string, name = 'model.gguf'): string {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, Buffer.from([0x47, 0x47, 0x55, 0x46, 0, 0]));
+  return file;
+}
+
+describe('Qwen embedding compatibility formatting', () => {
+  test('formats Qwen queries with instruct-style prompt and keeps documents raw', () => {
+    const uri = 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf';
+
+    expect(formatEmbeddingQuery('find auth middleware', uri)).toBe(
+      'Instruct: Given a code search query, retrieve relevant code symbols and implementation details.\nQuery: find auth middleware',
+    );
+    expect(formatEmbeddingDocument('function authMiddleware() {}', uri)).toBe(
+      'function authMiddleware() {}',
+    );
+  });
+
+  test('preserves legacy document text for default transformer profile', () => {
+    expect(formatEmbeddingDocument('function add() {}', 'minilm')).toBe('function add() {}');
+  });
+});
+
+describe('model URI parsing, GGUF validation, and download policy', () => {
+  test('parses hf explicit GGUF, hf quant shorthand, file URLs, and absolute paths', () => {
+    expect(parseModelUri('hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf')).toEqual({
+      scheme: 'hf',
+      org: 'Qwen',
+      repo: 'Qwen3-Embedding-0.6B-GGUF',
+      file: 'model.gguf',
+    });
+    expect(parseModelUri('hf:Qwen/Qwen3-Embedding-0.6B-GGUF:Q4_K_M')).toMatchObject({
+      scheme: 'hf',
+      quantization: 'Q4_K_M',
+    });
+
+    const absolute = path.resolve('/tmp/model.gguf');
+    expect(parseModelUri(`file://${absolute}`).scheme).toBe('file');
+    expect(parseModelUri(absolute)).toEqual({ scheme: 'file', file: absolute });
+  });
+
+  test('rejects missing, HTML-intercepted, and non-GGUF files with actionable errors', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-gguf-'));
+    try {
+      await expect(validateGgufFile(path.join(tmp, 'missing.gguf'))).rejects.toThrow(/not found/i);
+      const html = path.join(tmp, 'html.gguf');
+      fs.writeFileSync(html, '<html>huggingface login</html>');
+      await expect(validateGgufFile(html, 'hf:x/y/model.gguf')).rejects.toThrow(/looks like HTML/i);
+      const bad = path.join(tmp, 'bad.gguf');
+      fs.writeFileSync(bad, 'nope');
+      await expect(validateGgufFile(bad)).rejects.toThrow(/missing GGUF magic/i);
+      await expect(validateGgufFile(ggufFile(tmp))).resolves.toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('reports offline and no-auto-download cache misses without downloading', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-cache-'));
+    try {
+      const cache = new ModelCache(tmp);
+      await expect(
+        cache.ensureModel('hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf', 'embed', {
+          offline: true,
+          allowDownload: false,
+        }),
+      ).rejects.toThrow(/offline mode/i);
+      await expect(
+        cache.ensureModel('hf:Qwen/Qwen3-Embedding-0.6B-GGUF/model.gguf', 'embed', {
+          offline: false,
+          allowDownload: false,
+        }),
+      ).rejects.toThrow(/automatic downloads are disabled/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('resolves policy from env with offline taking precedence', () => {
+    expect(resolveDownloadPolicy({ HF_HUB_OFFLINE: '1', CODEGRAPH_NO_AUTO_DOWNLOAD: '1' })).toEqual(
+      {
+        offline: true,
+        allowDownload: false,
+      },
+    );
+    expect(resolveDownloadPolicy({ CODEGRAPH_NO_AUTO_DOWNLOAD: 'true' })).toEqual({
+      offline: false,
+      allowDownload: false,
+    });
+  });
+});
+
+describe('HTTP embedding port', () => {
+  test('calls OpenAI-compatible endpoint and orders vectors by response index', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { index: 1, embedding: [0, 1] },
+          { index: 0, embedding: [1, 0] },
+        ],
+      }),
+    } as Response);
+    try {
+      const port = new HttpEmbeddingPort('http://localhost:8000/v1/embeddings#qwen');
+      const vectors = await port.embedBatch(['a', 'b']);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8000/v1/embeddings',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ input: ['a', 'b'], model: 'qwen' }),
+        }),
+      );
+      expect(vectors.map((vector) => Array.from(vector))).toEqual([
+        [1, 0],
+        [0, 1],
+      ]);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+});
+
+describe('embedding port factory', () => {
+  test('creates Qwen GGUF port from local file without requiring node-llama-cpp until used', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-factory-'));
+    try {
+      const file = ggufFile(tmp, 'Qwen3-Embedding.gguf');
+      const runtimeLoader = vi.fn(async () => ({
+        getLlama: async () => ({
+          loadModel: async () => ({
+            createEmbeddingContext: async () => ({
+              getEmbeddingFor: async (text: string) => ({
+                vector: [text.includes('Instruct:') ? 1 : 0, 2],
+              }),
+            }),
+          }),
+        }),
+      }));
+
+      const port = await createEmbeddingPort(`file:${file}`, { inputType: 'query', runtimeLoader });
+      const [vector] = await port.embedBatch(['find parser']);
+      expect(runtimeLoader).toHaveBeenCalledTimes(1);
+      expect(Array.from(vector!)).toEqual([1, 2]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('wraps HTTP ports with Qwen query formatting when URI identifies Qwen', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ index: 0, embedding: [1] }] }),
+    } as Response);
+    try {
+      const port = await createEmbeddingPort('https://example.test/v1/embeddings#Qwen3-Embedding', {
+        inputType: 'query',
+      });
+      await port.embedBatch(['auth']);
+      const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string) as {
+        input: string[];
+      };
+      expect(body.input[0]).toMatch(/^Instruct:.*Query: auth/s);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+});

--- a/tests/search/rerank.test.ts
+++ b/tests/search/rerank.test.ts
@@ -177,6 +177,7 @@ describe('rerankCandidates', () => {
         name: 'exactMatch',
         fusionScore: 0.2,
         bm25Rank: 1,
+        lexicalExactTopHit: true,
         text: 'function exactMatch() {}',
       }),
       makeCandidate({

--- a/tests/search/rerank.test.ts
+++ b/tests/search/rerank.test.ts
@@ -355,6 +355,41 @@ describe('rerankCandidates', () => {
 
   // ── Text extraction fallback ──────────────────────────────────────
 
+  test('selects full text before content and preview fields', async () => {
+    const candidates = [
+      makeCandidate({
+        key: 'a',
+        text: undefined,
+        full_text: 'full snake text',
+        fullText: 'full camel text',
+        content: 'fts content',
+        text_preview: 'preview snake',
+        textPreview: 'preview camel',
+      } as Partial<RerankCandidate>),
+      makeCandidate({
+        key: 'b',
+        text: undefined,
+        content: 'fts content beats preview',
+        text_preview: 'preview loses',
+      } as Partial<RerankCandidate>),
+    ];
+
+    let passedDocuments: string[] = [];
+    const port: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        passedDocuments = documents;
+        return {
+          ok: true as const,
+          value: documents.map((_, index) => ({ index, score: 0.5 })),
+        };
+      },
+    };
+
+    await rerankCandidates(port, 'q', candidates);
+
+    expect(passedDocuments).toEqual(['full snake text', 'fts content beats preview']);
+  });
+
   test('uses name/file/line as fallback text when no text provided', async () => {
     const candidates = [
       makeCandidate({ key: 'a', name: 'myFunc', file: 'src/mod.ts', line: 42, text: undefined }),

--- a/tests/search/rerank.test.ts
+++ b/tests/search/rerank.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, test } from 'vitest';
+import {
+  type RerankCandidate,
+  type RerankPort,
+  rerankCandidates,
+} from '../../src/domain/search/search/rerank.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeCandidate(overrides: Partial<RerankCandidate> = {}): RerankCandidate {
+  return {
+    key: `func:file.ts:${overrides.line ?? 1}`,
+    name: overrides.name ?? 'testFunc',
+    kind: overrides.kind ?? 'function',
+    file: overrides.file ?? 'file.ts',
+    line: overrides.line ?? 1,
+    fusionScore: overrides.fusionScore ?? 0.1,
+    bm25Rank: overrides.bm25Rank ?? null,
+    text: overrides.text ?? 'function testFunc() { return 1; }',
+    ...overrides,
+  };
+}
+
+/** Create a mock RerankPort that returns fixed scores. */
+function mockPort(scores: Array<{ index: number; score: number }>): RerankPort {
+  return {
+    async rerank(_query: string, _documents: string[]) {
+      return {
+        ok: true as const,
+        value: scores.map((s) => ({ index: s.index, score: s.score })),
+      };
+    },
+  };
+}
+
+/** Create a mock RerankPort that always fails. */
+function failingPort(errorMsg = 'model unavailable'): RerankPort {
+  return {
+    async rerank() {
+      return { ok: false as const, error: new Error(errorMsg) };
+    },
+  };
+}
+
+/** Create a mock RerankPort that throws. */
+function throwingPort(errorMsg = 'catastrophic'): RerankPort {
+  return {
+    async rerank() {
+      throw new Error(errorMsg);
+    },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('rerankCandidates', () => {
+  // ── Fallback when no port ─────────────────────────────────────────
+
+  test('returns fusion-only ordering with normalized scores when rerank port is null', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', name: 'alpha', fusionScore: 0.3 }),
+      makeCandidate({ key: 'b', name: 'beta', fusionScore: 0.1 }),
+      makeCandidate({ key: 'c', name: 'gamma', fusionScore: 0.2 }),
+    ];
+
+    const result = await rerankCandidates(null, 'test query', candidates);
+
+    expect(result.reranked).toBe(false);
+    expect(result.fallbackReason).toBe('disabled');
+    expect(result.candidates[0]?.name).toBe('alpha');
+    expect(result.candidates[0]?.rerankScore).toBeNull();
+    // Normalized: alpha=1, gamma=0.5, beta=0
+    expect(result.candidates[0]?.blendedScore).toBeCloseTo(1);
+    expect(result.candidates[1]?.name).toBe('gamma');
+    expect(result.candidates[1]?.blendedScore).toBeCloseTo(0.5);
+    expect(result.candidates[2]?.name).toBe('beta');
+    expect(result.candidates[2]?.blendedScore).toBeCloseTo(0);
+  });
+
+  test('returns empty candidates unchanged', async () => {
+    const result = await rerankCandidates(null, 'q', []);
+    expect(result.candidates).toEqual([]);
+    expect(result.reranked).toBe(false);
+    expect(result.fallbackReason).toBe('none');
+  });
+
+  // ── Fallback on rerank error ──────────────────────────────────────
+
+  test('falls back to fusion-only with error metadata when port returns failure', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', name: 'alpha', fusionScore: 0.5 }),
+      makeCandidate({ key: 'b', name: 'beta', fusionScore: 0.2 }),
+    ];
+
+    const result = await rerankCandidates(failingPort(), 'test query', candidates);
+
+    expect(result.reranked).toBe(false);
+    expect(result.fallbackReason).toBe('error');
+    expect(result.candidates[0]?.name).toBe('alpha');
+    expect(result.candidates[0]?.rerankScore).toBeNull();
+    expect(result.candidates[0]?.explain?.rerankFallback).toBe(true);
+  });
+
+  test('falls back gracefully when port throws an exception', async () => {
+    const candidates = [makeCandidate({ key: 'a', fusionScore: 0.5 })];
+
+    const result = await rerankCandidates(throwingPort(), 'q', candidates);
+
+    expect(result.reranked).toBe(false);
+    expect(result.fallbackReason).toBe('error');
+    expect(result.candidates[0]?.rerankScore).toBeNull();
+  });
+
+  // ── Successful reranking ──────────────────────────────────────────
+
+  test('reranks candidates and blends scores with fusion', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', name: 'alpha', fusionScore: 0.1 }),
+      makeCandidate({ key: 'b', name: 'beta', fusionScore: 0.5 }),
+    ];
+
+    // Port scores beta higher (index 0 → alpha gets 0.2, index 1 → beta gets 0.9)
+    const port = mockPort([
+      { index: 0, score: 0.2 },
+      { index: 1, score: 0.9 },
+    ]);
+
+    const result = await rerankCandidates(port, 'test query', candidates, {
+      fusionWeight: 0.4,
+      rerankWeight: 0.6,
+    });
+
+    expect(result.reranked).toBe(true);
+    expect(result.fallbackReason).toBe('none');
+    // Beta should still rank higher due to high rerank + fusion
+    expect(result.candidates[0]?.name).toBe('beta');
+    expect(result.candidates[0]?.rerankScore).not.toBeNull();
+  });
+
+  // ── Candidate limits ──────────────────────────────────────────────
+
+  test('respects maxCandidates limit — only top fusion candidates are reranked', async () => {
+    const candidates = Array.from({ length: 10 }, (_, i) =>
+      makeCandidate({
+        key: `c${i}`,
+        name: `c${i}`,
+        fusionScore: 0.5 - i * 0.04,
+        text: `function c${i}() { return ${i}; }`,
+      }),
+    );
+
+    let rerankCallCount = 0;
+    const port: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        rerankCallCount = documents.length;
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: 0.5 })),
+        };
+      },
+    };
+
+    const result = await rerankCandidates(port, 'q', candidates, { maxCandidates: 3 });
+
+    expect(rerankCallCount).toBe(3);
+    expect(result.reranked).toBe(true);
+    // All 10 candidates should be returned (3 reranked + 7 remaining with penalty)
+    expect(result.candidates.length).toBe(10);
+  });
+
+  // ── Lexical-hit protection ────────────────────────────────────────
+
+  test('protects BM25 rank-1 hit from rerank-only demotion', async () => {
+    const candidates = [
+      makeCandidate({
+        key: 'lexical-top',
+        name: 'exactMatch',
+        fusionScore: 0.2,
+        bm25Rank: 1,
+        text: 'function exactMatch() {}',
+      }),
+      makeCandidate({
+        key: 'semantic-hit',
+        name: 'relatedFunc',
+        fusionScore: 0.5,
+        bm25Rank: null,
+        text: 'function relatedFunc() {}',
+      }),
+    ];
+
+    // Port gives the semantic hit a much higher score
+    const port = mockPort([
+      { index: 0, score: 0.1 },
+      { index: 1, score: 0.99 },
+    ]);
+
+    const result = await rerankCandidates(port, 'exactMatch', candidates, {
+      fusionWeight: 0.3,
+      rerankWeight: 0.7,
+    });
+
+    expect(result.reranked).toBe(true);
+    // The lexical top hit should be protected at position 0
+    expect(result.candidates[0]?.name).toBe('exactMatch');
+    expect(result.candidates[0]?.explain?.protectedLexicalHit).toBe(true);
+  });
+
+  test('does not protect when bm25Rank is not 1', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', name: 'a', fusionScore: 0.2, bm25Rank: 2 }),
+      makeCandidate({ key: 'b', name: 'b', fusionScore: 0.5, bm25Rank: null }),
+    ];
+
+    const port = mockPort([
+      { index: 0, score: 0.1 },
+      { index: 1, score: 0.9 },
+    ]);
+
+    const result = await rerankCandidates(port, 'q', candidates, {
+      fusionWeight: 0.3,
+      rerankWeight: 0.7,
+    });
+
+    expect(result.reranked).toBe(true);
+    // b should be first (higher fusion + rerank)
+    expect(result.candidates[0]?.name).toBe('b');
+    expect(result.candidates[0]?.explain?.protectedLexicalHit).toBeFalsy();
+  });
+
+  // ── Deterministic tie-breaking ────────────────────────────────────
+
+  test('breaks ties deterministically by key', async () => {
+    const candidates = [
+      makeCandidate({ key: 'b', name: 'b', fusionScore: 0.5, text: 'same text' }),
+      makeCandidate({ key: 'a', name: 'a', fusionScore: 0.5, text: 'same text' }),
+    ];
+
+    // Same rerank scores → tie
+    const port = mockPort([
+      { index: 0, score: 0.5 },
+      { index: 1, score: 0.5 },
+    ]);
+
+    const result = await rerankCandidates(port, 'q', candidates, {
+      fusionWeight: 0.5,
+      rerankWeight: 0.5,
+    });
+
+    expect(result.candidates[0]?.key).toBe('a');
+    expect(result.candidates[1]?.key).toBe('b');
+  });
+
+  // ── Intent-aware rerank query ─────────────────────────────────────
+
+  test('uses intent-aware query when intent is provided', async () => {
+    let capturedQuery = '';
+    const port: RerankPort = {
+      async rerank(query: string, documents: string[]) {
+        capturedQuery = query;
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: 0.5 })),
+        };
+      },
+    };
+
+    const candidates = [makeCandidate({ key: 'a', text: 'code' })];
+
+    await rerankCandidates(port, 'find auth', candidates, {
+      intent: 'user wants to locate authentication middleware',
+    });
+
+    // Intent-aware query should include the intent context
+    expect(capturedQuery).toContain('find auth');
+    expect(capturedQuery).toContain('user wants to locate authentication middleware');
+  });
+
+  test('uses plain query when no intent is provided', async () => {
+    let capturedQuery = '';
+    const port: RerankPort = {
+      async rerank(query: string, documents: string[]) {
+        capturedQuery = query;
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: 0.5 })),
+        };
+      },
+    };
+
+    const candidates = [makeCandidate({ key: 'a', text: 'code' })];
+
+    await rerankCandidates(port, 'simple query', candidates);
+
+    expect(capturedQuery).toBe('simple query');
+  });
+
+  // ── Duplicate text deduplication ──────────────────────────────────
+
+  test('deduplicates identical texts before calling port and maps scores back', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', name: 'a', text: 'identical code' }),
+      makeCandidate({ key: 'b', name: 'b', text: 'identical code' }),
+      makeCandidate({ key: 'c', name: 'c', text: 'different code' }),
+    ];
+
+    let passedDocuments: string[] = [];
+    const port: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        passedDocuments = documents;
+        // Score the unique texts
+        return {
+          ok: true as const,
+          value: documents.map((_, i) => ({ index: i, score: i === 0 ? 0.8 : 0.3 })),
+        };
+      },
+    };
+
+    const result = await rerankCandidates(port, 'q', candidates);
+
+    // Only 2 unique texts should have been sent
+    expect(passedDocuments.length).toBe(2);
+    expect(passedDocuments).toContain('identical code');
+    expect(passedDocuments).toContain('different code');
+    expect(result.reranked).toBe(true);
+    // Both 'a' and 'b' should get the same rerank score (mapped from dedup)
+    const a = result.candidates.find((c) => c.key === 'a');
+    const b = result.candidates.find((c) => c.key === 'b');
+    expect(a?.rerankScore).toBeCloseTo(b?.rerankScore ?? -1);
+  });
+
+  // ── Score normalization ───────────────────────────────────────────
+
+  test('normalizes fusion scores to 0-1 range', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', fusionScore: 0.5 }),
+      makeCandidate({ key: 'b', fusionScore: 0.1 }),
+    ];
+
+    const result = await rerankCandidates(null, 'q', candidates);
+
+    // a: (0.5 - 0.1) / (0.5 - 0.1) = 1.0
+    // b: (0.1 - 0.1) / (0.5 - 0.1) = 0.0
+    expect(result.candidates[0]?.blendedScore).toBeCloseTo(1);
+    expect(result.candidates[1]?.blendedScore).toBeCloseTo(0);
+  });
+
+  test('handles single candidate normalization (range = 0)', async () => {
+    const candidates = [makeCandidate({ key: 'a', fusionScore: 0.5 })];
+
+    const result = await rerankCandidates(null, 'q', candidates);
+
+    expect(result.candidates[0]?.blendedScore).toBeCloseTo(1);
+  });
+
+  // ── Text extraction fallback ──────────────────────────────────────
+
+  test('uses name/file/line as fallback text when no text provided', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', name: 'myFunc', file: 'src/mod.ts', line: 42, text: undefined }),
+    ];
+
+    let passedDocuments: string[] = [];
+    const port: RerankPort = {
+      async rerank(_query: string, documents: string[]) {
+        passedDocuments = documents;
+        return {
+          ok: true as const,
+          value: [{ index: 0, score: 0.5 }],
+        };
+      },
+    };
+
+    await rerankCandidates(port, 'q', candidates as any);
+
+    expect(passedDocuments[0]).toContain('myFunc');
+    expect(passedDocuments[0]).toContain('src/mod.ts');
+    expect(passedDocuments[0]).toContain('42');
+  });
+
+  // ── Remaining candidates penalty ──────────────────────────────────
+
+  test('applies penalty to candidates beyond maxCandidates', async () => {
+    const candidates = [
+      makeCandidate({ key: 'a', fusionScore: 0.8 }),
+      makeCandidate({ key: 'b', fusionScore: 0.5 }),
+      makeCandidate({ key: 'c', fusionScore: 0.3 }),
+    ];
+
+    const port = mockPort([
+      { index: 0, score: 0.5 },
+      { index: 1, score: 0.5 },
+    ]);
+
+    const result = await rerankCandidates(port, 'q', candidates, { maxCandidates: 2 });
+
+    expect(result.reranked).toBe(true);
+    // Candidate 'c' (index 2) was not reranked — should have rerankScore null
+    const c = result.candidates.find((c) => c.key === 'c');
+    expect(c?.rerankScore).toBeNull();
+    // Its blended score should be penalized (fusion-only × 0.5)
+    expect(c?.blendedScore).toBeLessThan(0.5);
+  });
+
+  // ── Explain metadata ──────────────────────────────────────────────
+
+  test('includes rerank explain metadata on each candidate', async () => {
+    const candidates = [makeCandidate({ key: 'a', fusionScore: 0.5 })];
+
+    const port = mockPort([{ index: 0, score: 0.8 }]);
+
+    const result = await rerankCandidates(port, 'q', candidates, {
+      fusionWeight: 0.4,
+      rerankWeight: 0.6,
+    });
+
+    expect(result.candidates[0]?.explain).toBeDefined();
+    expect(result.candidates[0]?.explain?.fusionWeight).toBe(0.4);
+    expect(result.candidates[0]?.explain?.rerankWeight).toBe(0.6);
+    expect(result.candidates[0]?.explain?.normalizedFusion).toBeDefined();
+    expect(result.candidates[0]?.explain?.normalizedRerank).toBeDefined();
+  });
+
+  test('includes fallback explain metadata when reranker fails', async () => {
+    const candidates = [makeCandidate({ key: 'a', fusionScore: 0.5 })];
+
+    const result = await rerankCandidates(failingPort(), 'q', candidates);
+
+    expect(result.candidates[0]?.explain?.rerankFallback).toBe(true);
+  });
+});

--- a/tests/search/search-command.test.ts
+++ b/tests/search/search-command.test.ts
@@ -57,4 +57,18 @@ describe('search command model option resolution', () => {
       expect.objectContaining({ model: 'minilm' }),
     );
   });
+
+  test('passes additive --expand flag through to search', async () => {
+    await command.execute?.(
+      ['needle'],
+      { limit: '15', minScore: '0.2', rrfK: '60', expand: true },
+      ctx(),
+    );
+
+    expect(searchMock).toHaveBeenCalledWith(
+      'needle',
+      undefined,
+      expect.objectContaining({ expand: true }),
+    );
+  });
 });

--- a/tests/search/search-command.test.ts
+++ b/tests/search/search-command.test.ts
@@ -72,6 +72,20 @@ describe('search command model option resolution', () => {
     );
   });
 
+  test('passes additive --explain flag through to search', async () => {
+    await command.execute?.(
+      ['needle'],
+      { limit: '15', minScore: '0.2', rrfK: '60', explain: true },
+      ctx(),
+    );
+
+    expect(searchMock).toHaveBeenCalledWith(
+      'needle',
+      undefined,
+      expect.objectContaining({ explain: true }),
+    );
+  });
+
   test('parses repeatable --query-mode values and disables generated expansion by default', async () => {
     await command.execute?.(
       ['auth flow'],

--- a/tests/search/search-command.test.ts
+++ b/tests/search/search-command.test.ts
@@ -89,11 +89,18 @@ describe('search command model option resolution', () => {
       undefined,
       expect.objectContaining({
         expand: false,
+        queryTextKind: 'plain',
         queryModes: [
           { mode: 'term', text: '"refresh token"' },
           { mode: 'intent', text: 'token rotation' },
         ],
       }),
+    );
+  });
+
+  test('rejects explicit hyde-only query-mode values without positional query text', () => {
+    expect(command.validate?.([''], { queryMode: ['hyde:hypothetical answer'] }, ctx())).toMatch(
+      /hyde-only inputs are not allowed/i,
     );
   });
 
@@ -109,6 +116,7 @@ describe('search command model option resolution', () => {
       undefined,
       expect.objectContaining({
         expand: false,
+        queryTextKind: 'plain',
         queryModes: [
           { mode: 'term', text: '"refresh token"' },
           { mode: 'intent', text: 'token rotation' },

--- a/tests/search/search-command.test.ts
+++ b/tests/search/search-command.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { CliContext } from '../../src/cli/types.js';
+
+const searchMock = vi.fn();
+const resolveModelRoleUriMock = vi.fn(() => 'preset-model-uri');
+
+vi.mock('../../src/domain/search/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/domain/search/index.js')>();
+  return {
+    ...actual,
+    resolveModelRoleUri: resolveModelRoleUriMock,
+    search: searchMock,
+  };
+});
+
+const { command } = await import('../../src/cli/commands/search.js');
+
+function ctx(): CliContext {
+  return {
+    config: { models: { preset: 'gno-compact' } },
+    resolveNoTests: () => false,
+    resolveQueryOpts: (opts) => opts,
+    formatSize: (bytes) => `${bytes}B`,
+    outputResult: () => false,
+    program: {} as CliContext['program'],
+  };
+}
+
+describe('search command model option resolution', () => {
+  beforeEach(() => {
+    searchMock.mockClear();
+    resolveModelRoleUriMock.mockClear();
+  });
+
+  test('leaves model undefined when --model is omitted so DB auto-detection can run', async () => {
+    await command.execute?.(['needle'], { limit: '15', minScore: '0.2', rrfK: '60' }, ctx());
+
+    expect(resolveModelRoleUriMock).not.toHaveBeenCalled();
+    expect(searchMock).toHaveBeenCalledWith(
+      'needle',
+      undefined,
+      expect.objectContaining({ model: undefined }),
+    );
+  });
+
+  test('passes explicit --model through to search', async () => {
+    await command.execute?.(
+      ['needle'],
+      { limit: '15', minScore: '0.2', model: 'minilm', rrfK: '60' },
+      ctx(),
+    );
+
+    expect(resolveModelRoleUriMock).not.toHaveBeenCalled();
+    expect(searchMock).toHaveBeenCalledWith(
+      'needle',
+      undefined,
+      expect.objectContaining({ model: 'minilm' }),
+    );
+  });
+});

--- a/tests/search/search-command.test.ts
+++ b/tests/search/search-command.test.ts
@@ -71,4 +71,58 @@ describe('search command model option resolution', () => {
       expect.objectContaining({ expand: true }),
     );
   });
+
+  test('parses repeatable --query-mode values and disables generated expansion by default', async () => {
+    await command.execute?.(
+      ['auth flow'],
+      {
+        limit: '15',
+        minScore: '0.2',
+        rrfK: '60',
+        queryMode: ['term:"refresh token"', 'intent:token rotation'],
+      },
+      ctx(),
+    );
+
+    expect(searchMock).toHaveBeenCalledWith(
+      'auth flow',
+      undefined,
+      expect.objectContaining({
+        expand: false,
+        queryModes: [
+          { mode: 'term', text: '"refresh token"' },
+          { mode: 'intent', text: 'token rotation' },
+        ],
+      }),
+    );
+  });
+
+  test('normalizes multi-line structured query syntax before searching', async () => {
+    await command.execute?.(
+      ['auth flow\nterm: "refresh token"\nintent: token rotation'],
+      { limit: '15', minScore: '0.2', rrfK: '60' },
+      ctx(),
+    );
+
+    expect(searchMock).toHaveBeenCalledWith(
+      'auth flow',
+      undefined,
+      expect.objectContaining({
+        expand: false,
+        queryModes: [
+          { mode: 'term', text: '"refresh token"' },
+          { mode: 'intent', text: 'token rotation' },
+        ],
+      }),
+    );
+  });
+
+  test('returns validation errors for invalid structured query inputs', () => {
+    expect(command.validate?.(['needle'], { queryMode: ['vector: nope'] }, ctx())).toMatch(
+      /Invalid --query-mode value/,
+    );
+    expect(command.validate?.(['needle\nterm:   '], {}, ctx())).toMatch(
+      /line 2 must contain non-empty text after term:/,
+    );
+  });
 });

--- a/tests/search/semantic-vector-acceleration.test.ts
+++ b/tests/search/semantic-vector-acceleration.test.ts
@@ -20,6 +20,7 @@ vi.mock('@huggingface/transformers', () => ({
 
 import {
   type ActiveEmbeddingMetadata,
+  createVectorIndex,
   encodeEmbedding,
   searchData,
   setVectorAccelerationDriverForTests,
@@ -136,6 +137,42 @@ describe('semantic search vector acceleration', () => {
     const result = await searchData('query', dbPath, { minScore: 0.9 });
 
     expect(result?.results.map((r) => r.name)).toEqual(['bruteForceWinner']);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('uses brute-force semantic search when filters are active so filtered top-k is complete', async () => {
+    const { dir, dbPath } = fixture();
+    const driver = fakeDriver((_db, _table, _query, k) =>
+      [{ nodeId: 2, distance: 0.01 }].slice(0, k),
+    );
+    setVectorAccelerationDriverForTests(driver);
+
+    const result = await searchData('query', dbPath, {
+      minScore: 0,
+      kind: 'function',
+      filePattern: 'a.ts',
+    });
+
+    expect(result?.results.map((r) => r.name)).toEqual(['bruteForceWinner']);
+    expect(driver.search).not.toHaveBeenCalled();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('falls back to brute force in a fresh process after persisted dirty acceleration state', async () => {
+    const { dir, dbPath } = fixture();
+    const writerDb = new Database(dbPath);
+    const dirty = createVectorIndex(writerDb, active, {
+      driver: fakeDriver(() => [{ nodeId: 2, distance: 0.01 }]),
+    });
+    dirty.vecDirty = true;
+    writerDb.close();
+    const driver = fakeDriver(() => [{ nodeId: 2, distance: 0.01 }]);
+    setVectorAccelerationDriverForTests(driver);
+
+    const result = await searchData('query', dbPath, { minScore: 0.9 });
+
+    expect(result?.results.map((r) => r.name)).toEqual(['bruteForceWinner']);
+    expect(driver.search).not.toHaveBeenCalled();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/search/semantic-vector-acceleration.test.ts
+++ b/tests/search/semantic-vector-acceleration.test.ts
@@ -20,6 +20,7 @@ vi.mock('@huggingface/transformers', () => ({
 
 import {
   type ActiveEmbeddingMetadata,
+  buildEmbeddings,
   createVectorIndex,
   encodeEmbedding,
   searchData,
@@ -43,7 +44,10 @@ const active: ActiveEmbeddingMetadata = {
   formatterVersion: 'codegraph-symbol-text-v1',
 };
 
-function fakeDriver(searchImpl?: VectorAccelerationDriver['search']): VectorAccelerationDriver {
+function fakeDriver(
+  searchImpl?: VectorAccelerationDriver['search'],
+  overrides: Partial<VectorAccelerationDriver> = {},
+): VectorAccelerationDriver {
   return {
     load: vi.fn(),
     createTable: vi.fn(),
@@ -52,6 +56,7 @@ function fakeDriver(searchImpl?: VectorAccelerationDriver['search']): VectorAcce
     rebuild: vi.fn(),
     sync: vi.fn(() => ({ added: 0, removed: 0 })),
     search: vi.fn(searchImpl ?? ((_db, _table, _query, _k) => [{ nodeId: 2, distance: 0.01 }])),
+    ...overrides,
   };
 }
 
@@ -152,6 +157,34 @@ describe('semantic search vector acceleration', () => {
       kind: 'function',
       filePattern: 'a.ts',
     });
+
+    expect(result?.results.map((r) => r.name)).toEqual(['bruteForceWinner']);
+    expect(driver.search).not.toHaveBeenCalled();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('falls back to brute force after full re-embed replaces vector storage while acceleration is unavailable', async () => {
+    const { dir, dbPath } = fixture();
+    fs.writeFileSync(path.join(dir, 'a.ts'), 'export function bruteForceWinner() { return 1; }\n');
+    fs.writeFileSync(path.join(dir, 'b.ts'), 'export function acceleratedWinner() { return 2; }\n');
+    setVectorAccelerationDriverForTests(
+      fakeDriver(undefined, {
+        load: () => {
+          throw new Error('sqlite-vec unavailable during re-embed');
+        },
+      }),
+    );
+
+    await buildEmbeddings(dir, 'minilm', dbPath, {
+      embeddingPort: {
+        embedBatch: async (texts) =>
+          texts.map((_, i) => (i === 0 ? makeVec([1, 0]) : makeVec([0, 1]))),
+      },
+    });
+
+    const driver = fakeDriver(() => [{ nodeId: 2, distance: 0.01 }]);
+    setVectorAccelerationDriverForTests(driver);
+    const result = await searchData('query', dbPath, { minScore: 0.9 });
 
     expect(result?.results.map((r) => r.name)).toEqual(['bruteForceWinner']);
     expect(driver.search).not.toHaveBeenCalled();

--- a/tests/search/semantic-vector-acceleration.test.ts
+++ b/tests/search/semantic-vector-acceleration.test.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { initSchema } from '../../src/db/index.js';
+
+const QUERY_VECTORS = new Map<string, Float32Array>();
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: async () => {
+    const extractor = async (batch: string[]) => ({
+      data: QUERY_VECTORS.get(batch[0]!) ?? new Float32Array(384),
+    });
+    extractor.dispose = async () => {};
+    return extractor;
+  },
+  cos_sim: () => 0,
+}));
+
+import {
+  type ActiveEmbeddingMetadata,
+  encodeEmbedding,
+  searchData,
+  setVectorAccelerationDriverForTests,
+  type VectorAccelerationDriver,
+  vectorStorageKey,
+  vectorTableName,
+} from '../../src/domain/search/index.js';
+
+function makeVec(components: number[]): Float32Array {
+  const vec = new Float32Array(384);
+  for (let i = 0; i < components.length; i++) vec[i] = components[i]!;
+  return vec;
+}
+
+const active: ActiveEmbeddingMetadata = {
+  modelUri: 'Xenova/all-MiniLM-L6-v2',
+  dimension: 384,
+  strategy: 'structured',
+  compatibilityProfile: 'default',
+  formatterVersion: 'codegraph-symbol-text-v1',
+};
+
+function fakeDriver(searchImpl?: VectorAccelerationDriver['search']): VectorAccelerationDriver {
+  return {
+    load: vi.fn(),
+    createTable: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+    rebuild: vi.fn(),
+    sync: vi.fn(() => ({ added: 0, removed: 0 })),
+    search: vi.fn(searchImpl ?? ((_db, _table, _query, _k) => [{ nodeId: 2, distance: 0.01 }])),
+  };
+}
+
+function fixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-vec-search-'));
+  const dbPath = path.join(dir, 'graph.db');
+  const db = new Database(dbPath);
+  initSchema(db);
+  db.exec(`
+    CREATE TABLE embeddings (node_id INTEGER PRIMARY KEY, vector BLOB NOT NULL, text_preview TEXT, full_text TEXT);
+    CREATE TABLE embedding_meta (key TEXT PRIMARY KEY, value TEXT);
+    INSERT INTO nodes (id, name, kind, file, line) VALUES
+      (1, 'bruteForceWinner', 'function', 'a.ts', 1),
+      (2, 'acceleratedWinner', 'function', 'b.ts', 2);
+  `);
+  db.prepare(
+    'INSERT INTO embeddings (node_id, vector, text_preview, full_text) VALUES (?, ?, ?, ?)',
+  ).run(1, encodeEmbedding(makeVec([1, 0])), 'brute', 'brute');
+  db.prepare(
+    'INSERT INTO embeddings (node_id, vector, text_preview, full_text) VALUES (?, ?, ?, ?)',
+  ).run(2, encodeEmbedding(makeVec([0, 1])), 'accelerated', 'accelerated');
+  const meta = db.prepare('INSERT INTO embedding_meta (key, value) VALUES (?, ?)');
+  for (const [key, value] of Object.entries({
+    model: active.modelUri,
+    dim: String(active.dimension),
+    model_uri: active.modelUri,
+    dimension: String(active.dimension),
+    strategy: active.strategy!,
+    compatibility_profile: active.compatibilityProfile,
+    formatter_version: active.formatterVersion,
+    count: '2',
+  }))
+    meta.run(key, value);
+  db.exec(
+    `CREATE TABLE ${vectorTableName(active)} (node_id INTEGER PRIMARY KEY, embedding BLOB NOT NULL)`,
+  );
+  db.prepare(`INSERT INTO ${vectorTableName(active)} (node_id, embedding) VALUES (?, ?)`).run(
+    2,
+    encodeEmbedding(makeVec([0, 1])),
+  );
+  db.exec(
+    `CREATE TABLE embedding_vectors (node_id INTEGER, model_uri TEXT, metadata_key TEXT, dimension INTEGER, vector BLOB, updated_at TEXT, PRIMARY KEY(node_id, metadata_key))`,
+  );
+  db.prepare(
+    'INSERT INTO embedding_vectors (node_id, model_uri, metadata_key, dimension, vector, updated_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)',
+  ).run(
+    2,
+    active.modelUri,
+    vectorStorageKey(active),
+    active.dimension,
+    encodeEmbedding(makeVec([0, 1])),
+  );
+  db.close();
+  QUERY_VECTORS.set('query', makeVec([1, 0]));
+  return { dir, dbPath };
+}
+
+afterEach(() => {
+  setVectorAccelerationDriverForTests(undefined);
+});
+
+describe('semantic search vector acceleration', () => {
+  test('uses accelerated KNN results when the optional driver is available', async () => {
+    const { dir, dbPath } = fixture();
+    const driver = fakeDriver();
+    setVectorAccelerationDriverForTests(driver);
+
+    const result = await searchData('query', dbPath, { minScore: 0 });
+
+    expect(result?.results.map((r) => r.name)).toEqual(['acceleratedWinner']);
+    expect(driver.search).toHaveBeenCalled();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('falls back to brute-force semantic search when accelerated lookup fails', async () => {
+    const { dir, dbPath } = fixture();
+    setVectorAccelerationDriverForTests(
+      fakeDriver(() => {
+        throw new Error('knn unavailable');
+      }),
+    );
+
+    const result = await searchData('query', dbPath, { minScore: 0.9 });
+
+    expect(result?.results.map((r) => r.name)).toEqual(['bruteForceWinner']);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/search/structured-query.test.ts
+++ b/tests/search/structured-query.test.ts
@@ -32,7 +32,7 @@ describe('structured query mode parsing and normalization', () => {
     expect(() => parseQueryModeSpecs(['hyde: one', 'hyde: two'])).toThrow(/Only one hyde/i);
   });
 
-  test('normalizes multi-line structured query syntax and derives base query from term or intent', () => {
+  test('normalizes multi-line structured query syntax and preserves plain vs derived base query source', () => {
     expect(
       normalizeStructuredQueryInput('auth flow\nterm: "refresh token"\nintent: token rotation'),
     ).toEqual({
@@ -43,6 +43,7 @@ describe('structured query mode parsing and normalization', () => {
       ],
       usedStructuredQuerySyntax: true,
       derivedQuery: false,
+      queryTextKind: 'plain',
     });
 
     expect(normalizeStructuredQueryInput('term: "refresh token"\nintent: token rotation')).toEqual({
@@ -53,6 +54,15 @@ describe('structured query mode parsing and normalization', () => {
       ],
       usedStructuredQuerySyntax: true,
       derivedQuery: true,
+      queryTextKind: 'term',
+    });
+
+    expect(normalizeStructuredQueryInput('intent: token rotation')).toEqual({
+      query: 'token rotation',
+      queryModes: [{ mode: 'intent', text: 'token rotation' }],
+      usedStructuredQuerySyntax: true,
+      derivedQuery: true,
+      queryTextKind: 'intent',
     });
   });
 
@@ -113,11 +123,58 @@ describe('structured query mode routing', () => {
 
     const routed = await routeExpandedQueries(
       'auth flow',
-      { queryModes: normalized.queryModes },
+      { queryModes: normalized.queryModes, queryTextKind: normalized.queryTextKind },
       [],
     );
     expect(routed.bm25Queries).toEqual(['auth flow']);
     expect(routed.semanticQueries).toEqual(['auth flow', 'Tokens rotate on use.']);
+  });
+
+  test('routes intent-only structured documents only to semantic search', async () => {
+    const normalized = normalizeStructuredQueryInput('intent: token rotation behavior');
+    const routed = await routeExpandedQueries(
+      normalized.query,
+      { queryModes: normalized.queryModes, queryTextKind: normalized.queryTextKind },
+      [],
+    );
+
+    expect(routed.bm25Queries).toEqual([]);
+    expect(routed.semanticQueries).toEqual(['token rotation behavior']);
+  });
+
+  test('routes term-only structured documents only to BM25 search', async () => {
+    const normalized = normalizeStructuredQueryInput('term: "refresh token"');
+    const routed = await routeExpandedQueries(
+      normalized.query,
+      { queryModes: normalized.queryModes, queryTextKind: normalized.queryTextKind },
+      [],
+    );
+
+    expect(routed.bm25Queries).toEqual(['"refresh token"']);
+    expect(routed.semanticQueries).toEqual([]);
+  });
+
+  test('routes mixed plain term intent documents to both only for plain text', async () => {
+    const normalized = normalizeStructuredQueryInput(
+      'auth flow\nterm: "refresh token"\nintent: token rotation behavior',
+    );
+    const routed = await routeExpandedQueries(
+      normalized.query,
+      { queryModes: normalized.queryModes, queryTextKind: normalized.queryTextKind },
+      [],
+    );
+
+    expect(routed.bm25Queries).toEqual(['auth flow', '"refresh token"']);
+    expect(routed.semanticQueries).toEqual(['auth flow', 'token rotation behavior']);
+  });
+
+  test('rejects explicit hyde-only modes without a positional query', async () => {
+    expect(() =>
+      normalizeStructuredQueryInput('', [{ mode: 'hyde', text: 'hypothetical answer' }]),
+    ).toThrow(/hyde-only inputs are not allowed/i);
+    await expect(
+      routeExpandedQueries('', { queryModes: [{ mode: 'hyde', text: 'hypothetical answer' }] }, []),
+    ).rejects.toThrow(/hyde-only inputs are not allowed/i);
   });
 
   test('routes structured modes without invoking generation provider', async () => {

--- a/tests/search/structured-query.test.ts
+++ b/tests/search/structured-query.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  buildExpansionFromQueryModes,
+  normalizeStructuredQueryInput,
+  parseQueryModeSpec,
+  parseQueryModeSpecs,
+  routeExpandedQueries,
+  validateQueryModes,
+} from '../../src/domain/search/search/expansion.js';
+
+describe('structured query mode parsing and normalization', () => {
+  test('parses explicit term intent and hyde query-mode specs', () => {
+    expect(parseQueryModeSpec('term:"refresh token"')).toEqual({
+      mode: 'term',
+      text: '"refresh token"',
+    });
+    expect(parseQueryModeSpec(' intent: token rotation ')).toEqual({
+      mode: 'intent',
+      text: 'token rotation',
+    });
+    expect(parseQueryModeSpec('hyde: Tokens rotate on use.')).toEqual({
+      mode: 'hyde',
+      text: 'Tokens rotate on use.',
+    });
+  });
+
+  test('rejects invalid explicit query-mode specs with actionable errors', () => {
+    expect(() => parseQueryModeSpec('vector: token rotation')).toThrow(
+      /Expected "term:<text>", "intent:<text>", or "hyde:<text>"/,
+    );
+    expect(() => parseQueryModeSpec('term:   ')).toThrow(/non-empty text after term:/);
+    expect(() => parseQueryModeSpecs(['hyde: one', 'hyde: two'])).toThrow(/Only one hyde/i);
+  });
+
+  test('normalizes multi-line structured query syntax and derives base query from term or intent', () => {
+    expect(
+      normalizeStructuredQueryInput('auth flow\nterm: "refresh token"\nintent: token rotation'),
+    ).toEqual({
+      query: 'auth flow',
+      queryModes: [
+        { mode: 'term', text: '"refresh token"' },
+        { mode: 'intent', text: 'token rotation' },
+      ],
+      usedStructuredQuerySyntax: true,
+      derivedQuery: false,
+    });
+
+    expect(normalizeStructuredQueryInput('term: "refresh token"\nintent: token rotation')).toEqual({
+      query: '"refresh token"',
+      queryModes: [
+        { mode: 'term', text: '"refresh token"' },
+        { mode: 'intent', text: 'token rotation' },
+      ],
+      usedStructuredQuerySyntax: true,
+      derivedQuery: true,
+    });
+  });
+
+  test('leaves plain single-line and untyped multi-line queries unchanged', () => {
+    expect(normalizeStructuredQueryInput('auth flow')).toMatchObject({
+      query: 'auth flow',
+      queryModes: [],
+      usedStructuredQuerySyntax: false,
+    });
+    expect(normalizeStructuredQueryInput('auth flow\nfind token code')).toMatchObject({
+      query: 'auth flow\nfind token code',
+      queryModes: [],
+      usedStructuredQuerySyntax: false,
+    });
+  });
+
+  test('rejects bad structured query documents', () => {
+    expect(() => normalizeStructuredQueryInput('auth\nvector: token rotation')).toThrow(
+      /Unknown structured query line prefix "vector:".*Expected term:, intent:, or hyde:/,
+    );
+    expect(() => normalizeStructuredQueryInput('auth\nterm:   ')).toThrow(
+      /line 2 must contain non-empty text after term:/,
+    );
+    expect(() => normalizeStructuredQueryInput('auth\nhyde: one\nhyde: two')).toThrow(
+      /Only one hyde line/,
+    );
+    expect(() => normalizeStructuredQueryInput('hyde: hypothetical answer\n')).toThrow(
+      /hyde-only documents are not allowed/,
+    );
+  });
+});
+
+describe('structured query mode routing', () => {
+  test('builds expansion shape with term only as BM25 and intent or hyde only as semantic', () => {
+    expect(
+      buildExpansionFromQueryModes([
+        { mode: 'term', text: '"refresh token"' },
+        { mode: 'intent', text: 'token rotation behavior' },
+        { mode: 'hyde', text: 'Refresh tokens rotate on each use.' },
+      ]),
+    ).toEqual({
+      lexicalQueries: ['"refresh token"'],
+      vectorQueries: ['token rotation behavior'],
+      hyde: 'Refresh tokens rotate on each use.',
+    });
+  });
+
+  test('rejects hyde-only query modes during validation', () => {
+    expect(() => validateQueryModes([{ mode: 'hyde', text: 'hypothetical answer' }])).toThrow(
+      /hyde-only inputs are not allowed/i,
+    );
+  });
+
+  test('allows hyde when a plain base query is present', async () => {
+    const normalized = normalizeStructuredQueryInput('auth flow\nhyde: Tokens rotate on use.');
+    expect(normalized.query).toBe('auth flow');
+    expect(normalized.queryModes).toEqual([{ mode: 'hyde', text: 'Tokens rotate on use.' }]);
+
+    const routed = await routeExpandedQueries(
+      'auth flow',
+      { queryModes: normalized.queryModes },
+      [],
+    );
+    expect(routed.bm25Queries).toEqual(['auth flow']);
+    expect(routed.semanticQueries).toEqual(['auth flow', 'Tokens rotate on use.']);
+  });
+
+  test('routes structured modes without invoking generation provider', async () => {
+    const provider = {
+      generate: vi.fn(async () => '{"lexicalQueries":["generated"],"vectorQueries":["generated"]}'),
+    };
+
+    const routed = await routeExpandedQueries(
+      'auth flow',
+      {
+        enabled: true,
+        provider,
+        queryModes: [
+          { mode: 'term', text: '"refresh token"' },
+          { mode: 'intent', text: 'token rotation behavior' },
+          { mode: 'hyde', text: 'Refresh tokens rotate on each use.' },
+        ],
+      },
+      [],
+    );
+
+    expect(provider.generate).not.toHaveBeenCalled();
+    expect(routed.skipped).toBeNull();
+    expect(routed.expansion).toEqual({
+      lexicalQueries: ['"refresh token"'],
+      vectorQueries: ['token rotation behavior'],
+      hyde: 'Refresh tokens rotate on each use.',
+    });
+    expect(routed.bm25Queries).toEqual(['auth flow', '"refresh token"']);
+    expect(routed.semanticQueries).toEqual([
+      'auth flow',
+      'token rotation behavior',
+      'Refresh tokens rotate on each use.',
+    ]);
+  });
+});

--- a/tests/search/vector-index.test.ts
+++ b/tests/search/vector-index.test.ts
@@ -152,6 +152,28 @@ describe('vector index acceleration', () => {
     expect(results.error.code).toBe('VECTOR_SEARCH_UNAVAILABLE');
   });
 
+  test('rejects vector rows whose metadata or dimension does not match the index', () => {
+    const database = db();
+    const index = createVectorIndex(database, meta, { driver: fakeDriver() });
+
+    const result = index.upsertVectors([
+      {
+        nodeId: 1,
+        model: meta.modelUri,
+        metadataKey: vectorStorageKey(meta),
+        embedding: new Float32Array([1, 0]),
+      },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? undefined : result.error.code).toBe('VECTOR_METADATA_MISMATCH');
+    expect(database.prepare('SELECT COUNT(*) as count FROM embedding_vectors').get()).toMatchObject(
+      {
+        count: 0,
+      },
+    );
+  });
+
   test('marks the accelerated index dirty when sync/rebuild writes fail but storage succeeds', () => {
     const database = db();
     const index = createVectorIndex(database, meta, {
@@ -179,7 +201,80 @@ describe('vector index acceleration', () => {
 
     expect(write.ok).toBe(true);
     expect(index.vecDirty).toBe(true);
+    expect(index.searchNearest(new Float32Array([1, 0, 0]), 1).ok).toBe(false);
     expect(index.syncVecIndex().ok).toBe(false);
     expect(index.rebuildVecIndex().ok).toBe(false);
+  });
+
+  test('persists dirty acceleration state across fresh index instances', () => {
+    const database = db();
+    const failing = createVectorIndex(database, meta, {
+      driver: fakeDriver({
+        upsert: () => {
+          throw new Error('vec write failed');
+        },
+      }),
+    });
+
+    expect(
+      failing.upsertVectors([
+        {
+          nodeId: 1,
+          model: meta.modelUri,
+          metadataKey: vectorStorageKey(meta),
+          embedding: new Float32Array([1, 0, 0]),
+        },
+      ]).ok,
+    ).toBe(true);
+
+    const fresh = createVectorIndex(database, meta, { driver: fakeDriver() });
+
+    expect(fresh.vecDirty).toBe(true);
+    const result = fresh.searchNearest(new Float32Array([1, 0, 0]), 1);
+    expect(result.ok).toBe(false);
+    expect(result.ok ? undefined : result.error.code).toBe('VECTOR_INDEX_DIRTY');
+  });
+
+  test('rebuild removes stale accelerated rows left from a previous full embed', () => {
+    const database = db();
+    const driver = fakeDriver({
+      rebuild: vi.fn((db, table, rows) => {
+        db.exec(`DELETE FROM ${table}`);
+        const insert = db.prepare(
+          `INSERT OR REPLACE INTO ${table} (node_id, embedding) VALUES (?, ?)`,
+        );
+        for (const row of rows) insert.run(row.nodeId, encodeEmbedding(row.embedding));
+      }),
+    });
+    const index = createVectorIndex(database, meta, { driver });
+    const metadataKey = vectorStorageKey(meta);
+    index.upsertVectors([
+      {
+        nodeId: 1,
+        model: meta.modelUri,
+        metadataKey,
+        embedding: new Float32Array([1, 0, 0]),
+      },
+      {
+        nodeId: 2,
+        model: meta.modelUri,
+        metadataKey,
+        embedding: new Float32Array([0, 1, 0]),
+      },
+    ]);
+
+    database.prepare('DELETE FROM embedding_vectors WHERE metadata_key = ?').run(metadataKey);
+    index.upsertVectors([
+      {
+        nodeId: 1,
+        model: meta.modelUri,
+        metadataKey,
+        embedding: new Float32Array([1, 0, 0]),
+      },
+    ]);
+    expect(index.rebuildVecIndex().ok).toBe(true);
+
+    const results = index.searchNearest(new Float32Array([0, 1, 0]), 10);
+    expect(results.ok && results.value.map((r) => r.nodeId)).toEqual([1]);
   });
 });

--- a/tests/search/vector-index.test.ts
+++ b/tests/search/vector-index.test.ts
@@ -5,6 +5,7 @@ import {
   createVectorIndex,
   decodeEmbedding,
   encodeEmbedding,
+  sqliteVecDriver,
   type VectorAccelerationDriver,
   vectorStorageKey,
 } from '../../src/domain/search/vector-index.js';
@@ -233,6 +234,54 @@ describe('vector index acceleration', () => {
     const result = fresh.searchNearest(new Float32Array([1, 0, 0]), 1);
     expect(result.ok).toBe(false);
     expect(result.ok ? undefined : result.error.code).toBe('VECTOR_INDEX_DIRTY');
+  });
+
+  test('sqlite-vec driver binds vector table primary keys as bigint', () => {
+    const calls: Array<{ sql: string; args: unknown[] }> = [];
+    const database = {
+      prepare: vi.fn((sql: string) => ({
+        run: vi.fn((...args: unknown[]) => calls.push({ sql, args })),
+      })),
+      transaction: vi.fn((fn: () => void) => fn),
+    };
+
+    sqliteVecDriver.upsert(database as unknown as Database.Database, 'vec_test', [
+      {
+        nodeId: 42,
+        model: meta.modelUri,
+        metadataKey: vectorStorageKey(meta),
+        embedding: new Float32Array([1, 0, 0]),
+      },
+    ]);
+
+    expect(calls).toEqual([
+      { sql: 'DELETE FROM vec_test WHERE node_id = ?', args: [42n] },
+      {
+        sql: 'INSERT INTO vec_test (node_id, embedding) VALUES (?, ?)',
+        args: [42n, expect.any(Buffer)],
+      },
+    ]);
+  });
+
+  test('marks dirty before direct rebuild and sync mutate the accelerated index', () => {
+    const database = db();
+    let index: ReturnType<typeof createVectorIndex>;
+    const driver = fakeDriver({
+      rebuild: vi.fn(() => {
+        expect(index.vecDirty).toBe(true);
+      }),
+      sync: vi.fn(() => {
+        expect(index.vecDirty).toBe(true);
+        return { added: 0, removed: 0 };
+      }),
+    });
+    index = createVectorIndex(database, meta, { driver });
+
+    expect(index.vecDirty).toBe(false);
+    expect(index.rebuildVecIndex().ok).toBe(true);
+    expect(index.vecDirty).toBe(false);
+    expect(index.syncVecIndex().ok).toBe(true);
+    expect(index.vecDirty).toBe(false);
   });
 
   test('rebuild removes stale accelerated rows left from a previous full embed', () => {

--- a/tests/search/vector-index.test.ts
+++ b/tests/search/vector-index.test.ts
@@ -1,0 +1,185 @@
+import Database from 'better-sqlite3';
+import { describe, expect, test, vi } from 'vitest';
+import { initSchema } from '../../src/db/index.js';
+import {
+  createVectorIndex,
+  decodeEmbedding,
+  encodeEmbedding,
+  type VectorAccelerationDriver,
+  vectorStorageKey,
+} from '../../src/domain/search/vector-index.js';
+
+const meta = {
+  modelUri: 'model-a',
+  dimension: 3,
+  strategy: 'structured',
+  compatibilityProfile: 'default',
+  formatterVersion: 'codegraph-symbol-text-v1',
+};
+
+function db() {
+  const db = new Database(':memory:');
+  initSchema(db);
+  db.exec(`
+    CREATE TABLE embeddings (node_id INTEGER PRIMARY KEY, vector BLOB NOT NULL, text_preview TEXT, full_text TEXT);
+    INSERT INTO nodes (id, name, kind, file, line) VALUES (1, 'a', 'function', 'a.ts', 1), (2, 'b', 'function', 'b.ts', 2);
+  `);
+  return db;
+}
+
+function fakeDriver(overrides: Partial<VectorAccelerationDriver> = {}): VectorAccelerationDriver {
+  return {
+    load: vi.fn(),
+    createTable: vi.fn((db, table) => {
+      db.exec(
+        `CREATE TABLE IF NOT EXISTS ${table} (node_id INTEGER PRIMARY KEY, embedding BLOB NOT NULL)`,
+      );
+    }),
+    upsert: vi.fn((db, table, rows) => {
+      const insert = db.prepare(
+        `INSERT OR REPLACE INTO ${table} (node_id, embedding) VALUES (?, ?)`,
+      );
+      for (const row of rows) insert.run(row.nodeId, encodeEmbedding(row.embedding));
+    }),
+    delete: vi.fn(),
+    search: vi.fn((db, table, query, k) => {
+      const rows = db.prepare(`SELECT node_id, embedding FROM ${table}`).all() as Array<{
+        node_id: number;
+        embedding: Buffer;
+      }>;
+      return rows
+        .map((row) => {
+          const vec = decodeEmbedding(row.embedding);
+          const dot = query.reduce((sum, value, i) => sum + value * (vec[i] ?? 0), 0);
+          return { nodeId: row.node_id, distance: 1 - dot };
+        })
+        .sort((a, b) => a.distance - b.distance)
+        .slice(0, k);
+    }),
+    rebuild: vi.fn(),
+    sync: vi.fn(() => ({ added: 0, removed: 0 })),
+    ...overrides,
+  };
+}
+
+describe('vector index acceleration', () => {
+  test('encodes and decodes vectors without sharing the original buffer', () => {
+    const vec = new Float32Array([1, 2, 3]);
+    const blob = encodeEmbedding(vec);
+    vec[0] = 9;
+    expect(Array.from(decodeEmbedding(blob))).toEqual([1, 2, 3]);
+  });
+
+  test('stores vectors in model-aware storage and accelerated index when available', () => {
+    const database = db();
+    const driver = fakeDriver();
+    const index = createVectorIndex(database, meta, { driver });
+
+    const result = index.upsertVectors([
+      {
+        nodeId: 1,
+        model: meta.modelUri,
+        metadataKey: vectorStorageKey(meta),
+        embedding: new Float32Array([1, 0, 0]),
+      },
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(index.searchAvailable).toBe(true);
+    const stored = database
+      .prepare('SELECT node_id, model_uri, metadata_key, dimension FROM embedding_vectors')
+      .get() as any;
+    expect(stored).toMatchObject({
+      node_id: 1,
+      model_uri: 'model-a',
+      metadata_key: vectorStorageKey(meta),
+      dimension: 3,
+    });
+    expect(driver.upsert).toHaveBeenCalled();
+  });
+
+  test('accelerated lookup is isolated by model metadata table', () => {
+    const database = db();
+    const driver = fakeDriver();
+    const a = createVectorIndex(database, meta, { driver });
+    const bMeta = { ...meta, modelUri: 'model-b' };
+    const b = createVectorIndex(database, bMeta, { driver });
+    a.upsertVectors([
+      {
+        nodeId: 1,
+        model: meta.modelUri,
+        metadataKey: vectorStorageKey(meta),
+        embedding: new Float32Array([1, 0, 0]),
+      },
+    ]);
+    b.upsertVectors([
+      {
+        nodeId: 2,
+        model: bMeta.modelUri,
+        metadataKey: vectorStorageKey(bMeta),
+        embedding: new Float32Array([0, 1, 0]),
+      },
+    ]);
+
+    const results = a.searchNearest(new Float32Array([1, 0, 0]), 10);
+
+    expect(results.ok && results.value.map((r) => r.nodeId)).toEqual([1]);
+  });
+
+  test('falls back cleanly when optional acceleration cannot load', () => {
+    const database = db();
+    const index = createVectorIndex(database, meta, {
+      driver: fakeDriver({
+        load: () => {
+          throw new Error('missing sqlite-vec');
+        },
+      }),
+    });
+
+    expect(index.searchAvailable).toBe(false);
+    expect(
+      index.upsertVectors([
+        {
+          nodeId: 1,
+          model: meta.modelUri,
+          metadataKey: vectorStorageKey(meta),
+          embedding: new Float32Array([1, 0, 0]),
+        },
+      ]).ok,
+    ).toBe(true);
+    const results = index.searchNearest(new Float32Array([1, 0, 0]), 1);
+    expect(results.ok).toBe(false);
+    expect(results.error.code).toBe('VECTOR_SEARCH_UNAVAILABLE');
+  });
+
+  test('marks the accelerated index dirty when sync/rebuild writes fail but storage succeeds', () => {
+    const database = db();
+    const index = createVectorIndex(database, meta, {
+      driver: fakeDriver({
+        upsert: () => {
+          throw new Error('vec write failed');
+        },
+        sync: () => {
+          throw new Error('sync failed');
+        },
+        rebuild: () => {
+          throw new Error('rebuild failed');
+        },
+      }),
+    });
+
+    const write = index.upsertVectors([
+      {
+        nodeId: 1,
+        model: meta.modelUri,
+        metadataKey: vectorStorageKey(meta),
+        embedding: new Float32Array([1, 0, 0]),
+      },
+    ]);
+
+    expect(write.ok).toBe(true);
+    expect(index.vecDirty).toBe(true);
+    expect(index.syncVecIndex().ok).toBe(false);
+    expect(index.rebuildVecIndex().ok).toBe(false);
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -75,6 +75,12 @@ describe('DEFAULTS', () => {
     expect(DEFAULTS.search).toEqual({
       defaultMinScore: 0.2,
       nearTopRankBonusMultiplier: 0.4,
+      rerank: {
+        enabled: false,
+        fusionWeight: 0.4,
+        maxCandidates: 20,
+        rerankWeight: 0.6,
+      },
       rrfK: 60,
       rrfWeights: {
         bm25: 2,

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -74,9 +74,19 @@ describe('DEFAULTS', () => {
   it('has search defaults', () => {
     expect(DEFAULTS.search).toEqual({
       defaultMinScore: 0.2,
+      nearTopRankBonusMultiplier: 0.4,
       rrfK: 60,
-      topK: 15,
+      rrfWeights: {
+        bm25: 2,
+        bm25Variant: 0.5,
+        hyde: 0.7,
+        vector: 2,
+        vectorVariant: 0.5,
+      },
       similarityWarnThreshold: 0.85,
+      topK: 15,
+      topRankBonus: 0.1,
+      topRankThreshold: 5,
     });
   });
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -58,7 +58,11 @@ describe('DEFAULTS', () => {
   });
 
   it('has embeddings defaults', () => {
-    expect(DEFAULTS.embeddings).toEqual({ model: 'nomic-v1.5', llmProvider: null });
+    expect(DEFAULTS.embeddings).toEqual({
+      model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      llmProvider: null,
+    });
+    expect(DEFAULTS.models.preset).toBe('gno-compact');
   });
 
   it('has llm defaults', () => {

--- a/tests/unit/mcp-semantic-search.test.ts
+++ b/tests/unit/mcp-semantic-search.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hybridSearchData = vi.fn();
+const searchData = vi.fn();
+const ftsSearchData = vi.fn();
+
+vi.mock('../../src/domain/search/index.js', () => ({
+  hybridSearchData,
+  searchData,
+  ftsSearchData,
+}));
+
+const ctx = {
+  dbPath: '/tmp/codegraph.db',
+  MCP_MAX_LIMIT: 50,
+} as any;
+
+describe('MCP semantic_search pipeline parity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to hybrid retrieval with expansion, reranking controls, and explain metadata', async () => {
+    hybridSearchData.mockResolvedValue({ results: [{ name: 'auth', explain: { sources: [] } }] });
+    const { handler } = await import('../../src/mcp/tools/semantic-search.js');
+
+    const result = await handler(
+      {
+        query: 'auth flow',
+        limit: 10,
+        explain: true,
+        rerank_candidates: 7,
+      },
+      ctx,
+    );
+
+    expect(result).toEqual({ results: [{ name: 'auth', explain: { sources: [] } }] });
+    expect(hybridSearchData).toHaveBeenCalledWith('auth flow', '/tmp/codegraph.db', {
+      limit: 10,
+      offset: 0,
+      minScore: undefined,
+      expand: true,
+      explain: true,
+      rerank: undefined,
+      rerankCandidates: 7,
+      queryModes: [],
+      queryTextKind: 'plain',
+      rrfK: undefined,
+    });
+  });
+
+  it('keeps MCP controls additive and supports disabling expansion and reranking', async () => {
+    hybridSearchData.mockResolvedValue({ results: [] });
+    const { handler } = await import('../../src/mcp/tools/semantic-search.js');
+
+    await handler(
+      {
+        query: 'intent: token rotation',
+        no_expand: true,
+        no_rerank: true,
+        rrf_k: 30,
+        query_mode: ['term:"refresh token"'],
+      },
+      ctx,
+    );
+
+    expect(hybridSearchData).toHaveBeenCalledWith('token rotation', '/tmp/codegraph.db', {
+      limit: 20,
+      offset: 0,
+      minScore: undefined,
+      expand: false,
+      explain: undefined,
+      rerank: false,
+      rerankCandidates: undefined,
+      queryModes: [
+        { mode: 'intent', text: 'token rotation' },
+        { mode: 'term', text: '"refresh token"' },
+      ],
+      queryTextKind: 'intent',
+      rrfK: 30,
+    });
+  });
+
+  it('falls back from hybrid to semantic when FTS is unavailable', async () => {
+    hybridSearchData.mockResolvedValue(null);
+    searchData.mockResolvedValue({ results: [{ name: 'semanticHit', similarity: 0.9 }] });
+    const { handler } = await import('../../src/mcp/tools/semantic-search.js');
+
+    const result = await handler({ query: 'auth' }, ctx);
+
+    expect(result).toEqual({ results: [{ name: 'semanticHit', similarity: 0.9 }] });
+    expect(searchData).toHaveBeenCalledWith('auth', '/tmp/codegraph.db', expect.any(Object));
+  });
+
+  it('falls back to keyword with actionable content when semantic embedding is unavailable', async () => {
+    hybridSearchData.mockRejectedValue(new Error('Embedding model unavailable'));
+    ftsSearchData.mockReturnValue({ results: [{ name: 'keywordHit', bm25Score: -1.2 }] });
+    const { handler } = await import('../../src/mcp/tools/semantic-search.js');
+
+    const result = await handler({ query: 'auth' }, ctx);
+
+    expect(result).toEqual({
+      results: [{ name: 'keywordHit', bm25Score: -1.2 }],
+      fallback: {
+        mode: 'keyword',
+        reason: 'Embedding model unavailable',
+        message: expect.stringContaining('Hybrid semantic retrieval unavailable'),
+      },
+    });
+  });
+
+  it('returns structured actionable errors when all retrieval paths are unavailable', async () => {
+    hybridSearchData.mockRejectedValue(new Error('vector search unavailable'));
+    ftsSearchData.mockReturnValue(null);
+    searchData.mockResolvedValue(null);
+    const { handler } = await import('../../src/mcp/tools/semantic-search.js');
+
+    const result = await handler({ query: 'auth' }, ctx);
+
+    expect(result).toMatchObject({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: expect.stringContaining('Semantic search unavailable'),
+        },
+      ],
+    });
+    expect((result as any).content[0].text).toContain('codegraph embed');
+  });
+});

--- a/tests/unit/mcp-semantic-search.test.ts
+++ b/tests/unit/mcp-semantic-search.test.ts
@@ -81,14 +81,21 @@ describe('MCP semantic_search pipeline parity', () => {
     });
   });
 
-  it('falls back from hybrid to semantic when FTS is unavailable', async () => {
+  it('falls back from hybrid to semantic with metadata when FTS is unavailable', async () => {
     hybridSearchData.mockResolvedValue(null);
     searchData.mockResolvedValue({ results: [{ name: 'semanticHit', similarity: 0.9 }] });
     const { handler } = await import('../../src/mcp/tools/semantic-search.js');
 
     const result = await handler({ query: 'auth' }, ctx);
 
-    expect(result).toEqual({ results: [{ name: 'semanticHit', similarity: 0.9 }] });
+    expect(result).toEqual({
+      results: [{ name: 'semanticHit', similarity: 0.9 }],
+      fallback: {
+        mode: 'semantic',
+        reason: 'FTS5 hybrid index unavailable',
+        message: expect.stringContaining('returned semantic-only results'),
+      },
+    });
     expect(searchData).toHaveBeenCalledWith('auth', '/tmp/codegraph.db', expect.any(Object));
   });
 

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -180,6 +180,7 @@ describe('TOOLS', () => {
           mode: { type: 'string', enum: ['term', 'intent', 'hyde'] },
           text: { type: 'string' },
         },
+        required: ['mode', 'text'],
       },
     ]);
     expect(ss.inputSchema.properties).toHaveProperty('explain');

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -172,6 +172,16 @@ describe('TOOLS', () => {
       { type: 'array', items: { type: 'string' } },
     ]);
     expect(ss.inputSchema.properties).toHaveProperty('query_modes');
+    expect(ss.inputSchema.properties.query_modes.items.oneOf).toEqual([
+      { type: 'string' },
+      {
+        type: 'object',
+        properties: {
+          mode: { type: 'string', enum: ['term', 'intent', 'hyde'] },
+          text: { type: 'string' },
+        },
+      },
+    ]);
     expect(ss.inputSchema.properties).toHaveProperty('explain');
   });
 

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -167,6 +167,10 @@ describe('TOOLS', () => {
     expect(ss.inputSchema.properties).toHaveProperty('no_rerank');
     expect(ss.inputSchema.properties).toHaveProperty('rerank_candidates');
     expect(ss.inputSchema.properties).toHaveProperty('query_mode');
+    expect(ss.inputSchema.properties.query_mode.oneOf).toEqual([
+      { type: 'string' },
+      { type: 'array', items: { type: 'string' } },
+    ]);
     expect(ss.inputSchema.properties).toHaveProperty('query_modes');
     expect(ss.inputSchema.properties).toHaveProperty('explain');
   });

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -156,11 +156,19 @@ describe('TOOLS', () => {
     expect(ch.inputSchema.properties).toHaveProperty('offset');
   });
 
-  it('semantic_search requires query parameter', () => {
+  it('semantic_search requires query parameter and exposes hybrid retrieval controls', () => {
     const ss = TOOLS.find((t) => t.name === 'semantic_search');
     expect(ss.inputSchema.required).toContain('query');
     expect(ss.inputSchema.properties).toHaveProperty('limit');
     expect(ss.inputSchema.properties).toHaveProperty('min_score');
+    expect(ss.inputSchema.properties).toHaveProperty('expand');
+    expect(ss.inputSchema.properties).toHaveProperty('no_expand');
+    expect(ss.inputSchema.properties).toHaveProperty('rerank');
+    expect(ss.inputSchema.properties).toHaveProperty('no_rerank');
+    expect(ss.inputSchema.properties).toHaveProperty('rerank_candidates');
+    expect(ss.inputSchema.properties).toHaveProperty('query_mode');
+    expect(ss.inputSchema.properties).toHaveProperty('query_modes');
+    expect(ss.inputSchema.properties).toHaveProperty('explain');
   });
 
   it('export_graph requires format parameter with enum', () => {

--- a/tests/unit/prompt-install.test.ts
+++ b/tests/unit/prompt-install.test.ts
@@ -185,4 +185,30 @@ describe('loadTransformers install prompt', () => {
     expect(result.dim).toBe(384);
     expect(exitSpy).not.toHaveBeenCalled();
   });
+
+  test('createTransformerEmbeddingPort without a model keeps the legacy transformer default', async () => {
+    process.stdin.isTTY = undefined;
+
+    const pipelineMock = vi.fn(async () => async (batch: string[]) => ({
+      data: new Float32Array(768 * batch.length),
+    }));
+    vi.doMock('node:readline', () => ({ createInterface: vi.fn() }));
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn() }));
+    vi.doMock('@huggingface/transformers', () => ({
+      pipeline: pipelineMock,
+      cos_sim: () => 0,
+    }));
+
+    const { createTransformerEmbeddingPort, MODELS, LEGACY_TRANSFORMER_DEFAULT_MODEL } =
+      await import('../../src/domain/search/index.js');
+
+    const vectors = await createTransformerEmbeddingPort().embedBatch(['test text']);
+
+    expect(vectors).toHaveLength(1);
+    expect(pipelineMock).toHaveBeenCalledWith(
+      'feature-extraction',
+      MODELS[LEGACY_TRANSFORMER_DEFAULT_MODEL]!.name,
+      {},
+    );
+  });
 });


### PR DESCRIPTION
## Parent

Implements #1: Bring GNO-style embedding, expansion, and reranking workflow into Codegraph.

## Completed issues included

- #2 — role-based retrieval model presets
- #3 — embedding port abstraction and recovery fallback
- #4 — Qwen/GGUF/HTTP embedding ports and cache policy
- #5 — vector metadata diagnostics for stale/incompatible embeddings
- #6 — optional vector acceleration with brute-force fallback
- #7 — guarded query expansion pipeline
- #8 — structured query modes (`term`, `intent`, `hyde`)
- #9 — weighted RRF fusion and explain metadata
- #10 — optional cross-encoder reranking with safe blending/fallbacks
- #11 — MCP `semantic_search` parity with hybrid retrieval controls
- #12 — reproducible retrieval benchmark harness and fixtures
- #13 — default decision implemented: use GNO/Qwen compact defaults for everything
- #14 — retrieval workflow docs, migration guidance, and GNO MIT attribution

## Default decision

Maintainer decision for #13: switch defaults now.

This PR changes the default retrieval preset to `gno-compact` and the default embedding model/config to the GNO/Qwen compact GGUF embedding URI. The legacy `codegraph-default` preset remains available, and explicit legacy config such as `embeddings.model: "nomic-v1.5"` continues to override the default embedding role.

## WASM test harness fix

The noisy WASM failures were caused by a stale incremental TypeScript build state: `dist/` had been removed while `.tsbuildinfo` remained, so plain `tsc` reported success without re-emitting `dist/domain/wasm-worker-entry.js`. The build script now uses `tsc --build --force` and creates `dist/` before writing the CJS wrapper.

Verified tight loop:

- `rm -rf dist && npm run build`
- `find dist src -name 'wasm-worker-entry*'` shows `dist/domain/wasm-worker-entry.js`
- `npx vitest run tests/parsers/wasm-hardening.test.ts` — pass
- `npx vitest run tests/parsers/unified.test.ts` — pass
- `npx vitest run tests/integration/config-include-exclude.test.ts` — pass
- `npx vitest run tests/engines/query-walk-parity.test.ts` — pass
- `npx vitest run tests/integration/qualified-names.test.ts tests/parsers/ast-nodes.test.ts tests/integration/branch-compare.test.ts` — pass

## Verification

Passing on the coordinator branch after #13 and the WASM harness fix:

- `npm run typecheck`
- Focused retrieval/default/MCP/benchmark tests — 9 files / 129 tests passed
- `npm run build`
- `npm run lint` — completed with existing warnings only
- `codegraph build .`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null npm test` — 170 files passed, 2803 tests passed, 7 skipped

## Local Pi QA

Local QA artifact: `/home/will/projects/ops-codegraph-tool/.worktrees/issue-1-gno-retrieval-workflow/coordinator/qa-results/report.md`

Summary: `:grey_question: INCONCLUSIVE — no app surface changed`. This repo change affects CLI/library/search/MCP/docs/benchmarks, not a web or native app surface. Verification gates are green.

## Non-blocking reviewer notes

- #12: benchmark CLI argument validation can be tightened later; real transformer lanes rely on Hugging Face offline envs, while `--allow-downloads` gates GGUF/cache policy.
- `npm run lint` still reports existing warnings outside this PR's scope.

## Merge recommendation

**Recommend merge.**

All scoped child issues are implemented, focused verification passes, the WASM worker-entry harness issue is fixed, and the full test suite passes under clean git config.
