### PR TITLE
chore: clean up lint warnings

### DIFF
--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -1,18 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { Tree } from 'web-tree-sitter';
 import { Language, Parser, Query } from 'web-tree-sitter';
 import { debug, warn } from '../infrastructure/logger.js';
 import { getNative, getNativePackageVersion, loadNative } from '../infrastructure/native.js';
 import { ParseError, toErrorMessage } from '../shared/errors.js';
-import type {
-  EngineMode,
-  ExtractorOutput,
-  LanguageId,
-  LanguageRegistryEntry,
-  TypeMapEntry,
-} from '../types.js';
+import type { EngineMode, ExtractorOutput, LanguageRegistryEntry, TypeMapEntry } from '../types.js';
 import { disposeWasmWorkerPool, getWasmWorkerPool } from './wasm-worker-pool.js';
 import type { WorkerAnalysisOpts } from './wasm-worker-protocol.js';
 
@@ -141,12 +134,6 @@ interface ResolvedEngine {
   native: any;
 }
 
-interface WasmExtractResult {
-  symbols: ExtractorOutput;
-  tree: Tree;
-  langId: LanguageId;
-}
-
 // Shared patterns for all JS/TS/TSX (class_declaration excluded — name type differs)
 const COMMON_QUERY_PATTERNS: string[] = [
   '(function_declaration name: (identifier) @fn_name) @fn_node',
@@ -223,25 +210,6 @@ async function initParserRuntime(): Promise<void> {
   }
   if (!_cachedParsers) _cachedParsers = new Map();
   if (!_cachedLanguages) _cachedLanguages = new Map();
-}
-
-/**
- * Load only the WASM grammars needed for the given file paths.
- * Grammars already in cache are reused. This avoids the ~500ms cold-start
- * penalty of loading all 23+ grammars when only 1-2 are needed (e.g. incremental rebuilds).
- */
-async function ensureParsersForFiles(filePaths: string[]): Promise<Map<string, Parser | null>> {
-  await initParserRuntime();
-  const needed = new Set<LanguageRegistryEntry>();
-  for (const fp of filePaths) {
-    const ext = path.extname(fp).toLowerCase();
-    const entry = _extToLang.get(ext);
-    if (entry && !_cachedParsers!.has(entry.id)) needed.add(entry);
-  }
-  for (const entry of needed) {
-    await loadLanguage(entry);
-  }
-  return _cachedParsers!;
 }
 
 /**
@@ -915,44 +883,6 @@ async function backfillTypeMap(
     return { typeMap: new Map(), backfilled: false };
   }
   return { typeMap: output.typeMap, backfilled: true };
-}
-
-/**
- * WASM extraction helper: picks the right extractor based on file extension.
- */
-function wasmExtractSymbols(
-  parsers: Map<string, Parser | null>,
-  filePath: string,
-  code: string,
-): WasmExtractResult | null {
-  const parser = getParser(parsers, filePath);
-  if (!parser) return null;
-
-  let tree: Tree | null;
-  try {
-    tree = parser.parse(code);
-  } catch (e: unknown) {
-    warn(`Parse error in ${filePath}: ${(e as Error).message}`);
-    return null;
-  }
-  if (!tree) return null;
-
-  const ext = path.extname(filePath);
-  const entry = _extToLang.get(ext);
-  if (!entry) return null;
-  const query = _queryCache.get(entry.id) ?? undefined;
-  // Query (web-tree-sitter) is structurally compatible with TreeSitterQuery at runtime
-  let symbols: ExtractorOutput | null;
-  try {
-    symbols = entry.extractor(tree as any, filePath, query as any);
-  } catch (e: unknown) {
-    warn(`Extractor error in ${filePath}: ${(e as Error).message}`);
-    // Free WASM tree to prevent memory leak — web-tree-sitter trees are backed
-    // by WASM linear memory and are not garbage-collected automatically.
-    if (typeof (tree as any).delete === 'function') (tree as any).delete();
-    return null;
-  }
-  return symbols ? { symbols, tree, langId: entry.id } : null;
 }
 
 /**

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -667,8 +667,7 @@ async function handleParse(msg: WorkerParseRequest): Promise<SerializedExtractor
     try {
       const query = _queries.get(entry.id);
       // tree-sitter's Tree/Query are structurally compatible with
-      // TreeSitterTree/TreeSitterQuery at runtime — same cast style as
-      // parser.ts::wasmExtractSymbols (parser.ts:789).
+      // TreeSitterTree/TreeSitterQuery at runtime.
       symbols = entry.extractor(tree as any, msg.filePath, query as any) ?? null;
     } catch {
       return null;

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1548,7 +1548,7 @@ function extractCallbackDefinition(
   // Express: app.get('/path', callback)
   if (EXPRESS_METHODS.has(method)) {
     const strArg = findFirstStringArg(args);
-    if (!strArg || !strArg.startsWith('/')) return null;
+    if (!strArg?.startsWith('/')) return null;
     const cb = findAnonymousCallback(args);
     if (!cb) return null;
     return {

--- a/tests/benchmarks/resolution/tracer/loader-hooks.mjs
+++ b/tests/benchmarks/resolution/tracer/loader-hooks.mjs
@@ -106,7 +106,7 @@ function instrumentSource(source, filename) {
 
     // Insert enter/try for new function declarations
     if (funcName && trimmed.endsWith('{')) {
-      const inner = indent + '  ';
+      const inner = `${indent}  `;
       const escaped = funcName.replace(/'/g, "\\'");
       output.push(`${inner}globalThis.__tracer?.enter('${escaped}', '${file}');`);
       output.push(`${inner}try {`);

--- a/tests/engines/dataflow-parity.test.ts
+++ b/tests/engines/dataflow-parity.test.ts
@@ -37,7 +37,7 @@ function wasmDataflow(code, filePath, langId) {
  */
 function nativeDataflow(code, filePath) {
   const result = native.parseFile(filePath, code, true);
-  if (!result || !result.dataflow) return null;
+  if (!result?.dataflow) return null;
   const df = result.dataflow;
   return {
     parameters: (df.parameters || []).map((p) => ({

--- a/tests/integration/roles.test.ts
+++ b/tests/integration/roles.test.ts
@@ -112,8 +112,8 @@ describe('barrel re-export role classification', () => {
 
     // Symbol nodes
     const queryName = insertNode(db, 'queryName', 'function', 'src/inspect.ts', 10);
-    const helperFn = insertNode(db, 'helperFn', 'function', 'src/inspect.ts', 30);
-    const appMain = insertNode(db, 'appMain', 'function', 'src/app.ts', 1);
+    insertNode(db, 'helperFn', 'function', 'src/inspect.ts', 30);
+    insertNode(db, 'appMain', 'function', 'src/app.ts', 1);
     const testFn = insertNode(db, 'testQueryName', 'function', 'tests/inspect.test.ts', 1);
 
     // Barrel re-exports inspect.ts
@@ -190,7 +190,7 @@ describe('multi-level barrel re-export chain', () => {
     const fQueriesCli = insertNode(db, 'src/queries-cli.ts', 'file', 'src/queries-cli.ts', 0);
     const fQuery = insertNode(db, 'src/query.ts', 'file', 'src/query.ts', 0);
 
-    const queryName = insertNode(db, 'queryName', 'function', 'src/queries-cli/inspect.ts', 10);
+    insertNode(db, 'queryName', 'function', 'src/queries-cli/inspect.ts', 10);
     insertNode(db, 'queryCmd', 'function', 'src/query.ts', 1);
 
     // Barrel chain: each barrel re-exports from the one below

--- a/tests/unit/visitor.test.ts
+++ b/tests/unit/visitor.test.ts
@@ -4,7 +4,6 @@
 import { describe, expect, it } from 'vitest';
 
 // We need a tree-sitter tree to test. Use the JS parser.
-// biome-ignore lint/suspicious/noExplicitAny: tree-sitter parser type is complex and not worth typing for tests
 let parse: any;
 
 async function ensureParser() {


### PR DESCRIPTION
## Summary
- remove two dead private parser helpers left behind by the worker-based WASM path
- apply safe Biome style cleanups for optional chaining and template literals
- remove unused test assignments/suppression while preserving fixture side effects
- update a stale worker comment that referenced the removed helper

## Verification
- `npm run lint`
- `npm run typecheck`
- `npx vitest run tests/unit/parser.test.ts tests/integration/roles.test.ts tests/unit/visitor.test.ts tests/engines/dataflow-parity.test.ts tests/parsers/javascript.test.ts`
- `npm run build`
- `node dist/cli.js build`
- `node dist/cli.js diff-impact --staged -T`
- `npm audit` reports 0 vulnerabilities