### PR TITLE
test: exclude worktrees from vitest discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     globals: true,
     testTimeout: 30000,
     hookTimeout: 30000,
-    exclude: ['**/node_modules/**', '**/.git/**', '**/.claude/**'],
+    exclude: ['**/node_modules/**', '**/.git/**', '**/.claude/**', '**/.worktrees/**'],
     // Ensure child processes spawned by tests (e.g. CLI integration tests)
     // can load .ts files via Node's built-in type stripping.
     env: {


### PR DESCRIPTION
## Summary
- add `**/.worktrees/**` to Vitest test discovery exclusions
- prevents `npm test` from recursively running tests inside local agent/worktree checkouts

## Verification
- created a temporary `.worktrees/.../should-not-run.test.ts` and confirmed Vitest discovered it before the change
- confirmed the same temporary test was no longer listed after the change
- `npm run lint`
- `npm run typecheck`
- `npx vitest list --passWithNoTests` reports no `.worktrees` entries