### PR TITLE
fix(cli): clarify models output for GNO retrieval

### DIFF
--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -1,36 +1,54 @@
-import { MODELS, resolveModelRoleUri } from '../../domain/search/index.js';
+import {
+  MODELS,
+  RETRIEVAL_MODEL_PRESETS,
+  resolveRetrievalModels,
+} from '../../domain/search/index.js';
 import type { CommandDefinition } from '../types.js';
+
+const ROLE_ORDER = ['embed', 'rerank', 'expand', 'gen'] as const;
+
+interface ModelEntry {
+  dim: number;
+  desc: string;
+  contextWindow?: number;
+  name: string;
+}
 
 export const command: CommandDefinition = {
   name: 'models',
-  description: 'List available embedding models',
+  description: 'List retrieval presets and embedding model aliases',
   execute(_args, _opts, ctx) {
-    const defaultRoleModel = resolveModelRoleUri(ctx.config, 'embed');
-    console.log('\nAvailable embedding models:\n');
+    const resolved = resolveRetrievalModels(ctx.config);
+    const activeEmbed = resolved.roles.embed;
+    const requestedFallback = resolved.requestedPreset
+      ? ` (requested "${resolved.requestedPreset}" not found)`
+      : '';
 
-    interface ModelEntry {
-      dim: number;
-      desc: string;
-      contextWindow?: number;
-      name: string;
+    console.log(`\nActive retrieval preset: ${resolved.preset}${requestedFallback}`);
+    console.log('\nActive retrieval roles:\n');
+    for (const role of ROLE_ORDER) {
+      console.log(`  ${role.padEnd(7)} ${resolved.roles[role]}`);
     }
 
+    console.log('\nRetrieval presets:\n');
+    for (const [key, preset] of Object.entries(RETRIEVAL_MODEL_PRESETS)) {
+      const marker = key === resolved.preset ? '(active)' : '';
+      console.log(`  ${key.padEnd(18)} ${marker.padEnd(9)} ${preset.desc}`);
+    }
+
+    console.log('\nEmbedding aliases (--model overrides):\n');
     for (const [key, cfg] of Object.entries(MODELS)) {
       const modelCfg = cfg as ModelEntry;
-      const def =
-        key === defaultRoleModel || modelCfg.name === defaultRoleModel ? ' (default)' : '';
+      const marker = key === activeEmbed || modelCfg.name === activeEmbed ? ' (active embed)' : '';
       const ctxWindow = modelCfg.contextWindow ? `${modelCfg.contextWindow} ctx` : '';
       console.log(
-        `  ${key.padEnd(12)} ${String(modelCfg.dim).padStart(4)}d  ${ctxWindow.padEnd(9)} ${modelCfg.desc}${def}`,
+        `  ${key.padEnd(12)} ${String(modelCfg.dim).padStart(4)}d  ${ctxWindow.padEnd(9)} ${modelCfg.desc}${marker}`,
       );
     }
-    if (
-      !MODELS[defaultRoleModel] &&
-      !Object.values(MODELS).some((cfg) => cfg.name === defaultRoleModel)
-    ) {
-      console.log(`\nDefault embedding role: ${defaultRoleModel}`);
-    }
-    console.log('\nUsage: codegraph embed --model <name-or-uri> --strategy <structured|source>');
-    console.log('       codegraph search "query" --model <name-or-uri>\n');
+
+    console.log('\nUsage:');
+    console.log('  codegraph embed [--model <alias-or-uri>] [--strategy <structured|source>]');
+    console.log('  codegraph search "query" [--model <alias-or-uri>]');
+    console.log('  .codegraphrc.json: { "models": { "preset": "gno-balanced" } }\n');
   },
 };

--- a/tests/search/models-command.test.ts
+++ b/tests/search/models-command.test.ts
@@ -19,27 +19,60 @@ function ctx(config: Partial<CodegraphConfig> = {}): CliContext {
   };
 }
 
+function runModelsCommand(config: Partial<CodegraphConfig> = {}): string {
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  command.execute?.([], {}, ctx(config));
+  return log.mock.calls.map((call) => call.join(' ')).join('\n');
+}
+
 describe('models command defaults', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test('marks the resolved embed role instead of stale embeddings.model', () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  test('shows active GNO retrieval roles before legacy embedding aliases', () => {
+    const output = runModelsCommand();
 
-    command.execute?.(
-      [],
-      {},
-      ctx({
-        embeddings: { model: 'minilm', llmProvider: null },
-        models: { preset: 'gno-balanced' },
-      }),
-    );
-
-    const output = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(output).toContain('Active retrieval preset: gno-compact');
+    expect(output).toContain('Active retrieval roles:');
     expect(output).toContain(
-      'Default embedding role: hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+      'embed   hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
+    );
+    expect(output).toContain(
+      'rerank  hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
+    );
+    expect(output).toContain('Retrieval presets:');
+    expect(output).toMatch(/gno-compact\s+\(active\)/);
+    expect(output).toContain('gno-balanced');
+    expect(output).toContain('gno-quality');
+    expect(output).toContain('Embedding aliases (--model overrides):');
+    expect(output).not.toContain('Available embedding models:');
+    expect(output.indexOf('Active retrieval roles:')).toBeLessThan(
+      output.indexOf('Embedding aliases (--model overrides):'),
+    );
+  });
+
+  test('marks resolved embed overrides without calling legacy aliases the default', () => {
+    const output = runModelsCommand({
+      embeddings: { model: 'minilm', llmProvider: null },
+      models: { preset: 'gno-balanced' },
+    });
+
+    expect(output).toContain('Active retrieval preset: gno-balanced');
+    expect(output).toContain(
+      'embed   hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
     );
     expect(output).not.toMatch(/minilm.*\(default\)/);
+  });
+
+  test('labels a configured legacy embedding alias as the active embed role', () => {
+    const output = runModelsCommand({
+      embeddings: { model: 'bge-large', llmProvider: null },
+    });
+
+    expect(output).toContain('embed   Xenova/bge-large-en-v1.5');
+    expect(output).toMatch(
+      /bge-large\s+1024d\s+512 ctx\s+Best general retrieval.*\(active embed\)/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- restructure `codegraph models` around active retrieval presets and roles
- show GNO role URIs for embed/rerank/expand/gen instead of burying the active model after legacy aliases
- keep legacy embedding aliases visible as explicit `--model` overrides
- label active presets and active embed aliases when config overrides the embed role

## Verification
- `npx vitest run tests/search/models-command.test.ts tests/search/model-presets.test.ts tests/search/embed-command.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `node dist/cli.js build`
- `node dist/cli.js diff-impact --staged -T`
- `npm audit` reports 0 vulnerabilities
- inspected `node dist/cli.js models` with and without repo config override