### PR TITLE
fix(search): align retrieval presets with GNO

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,10 +395,10 @@ codegraph cycles --functions   # Function-level cycles
 
 ### Semantic Search
 
-Local embeddings for every function, method, and class — search by natural language. The default retrieval preset is `gno-compact` with the Qwen compact GGUF embedding role; legacy transformer aliases and HTTP embedding backends are documented in the [retrieval workflow guide](docs/guides/retrieval-workflow.md).
+Local embeddings for every function, method, and class — search by natural language. The default retrieval preset is `slim-tuned`, matching GNO’s local model stack with Qwen GGUF embeddings and fine-tuned query expansion; legacy transformer aliases and HTTP embedding backends are documented in the [retrieval workflow guide](docs/guides/retrieval-workflow.md).
 
 ```bash
-codegraph embed                # Build embeddings (default: GNO/Qwen compact GGUF)
+codegraph embed                # Build embeddings (default: GNO slim-tuned / Qwen GGUF)
 codegraph embed --model nomic  # Use a different model
 codegraph search "handle authentication"
 codegraph search "parse config" --min-score 0.4 -n 10

--- a/docs/benchmarks/RETRIEVAL.md
+++ b/docs/benchmarks/RETRIEVAL.md
@@ -20,11 +20,11 @@ Compared model lanes:
 
 ## Issue #13 decision summary
 
-Maintainer decision: switch defaults now to the GNO/Qwen compact path for all retrieval roles. `gno-compact` is the default preset, and the default embedding role is `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf`.
+Maintainer decision: switch defaults now to GNO’s local model stack. `slim-tuned` is the default preset, and the default embedding role is `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf`.
 
 Review summary from the benchmark lane design and migration assessment:
 
-- **Quality:** the GNO/Qwen compact lane is the target higher-quality code retrieval path and is now preferred over the legacy `nomic-v1.5` baseline; the benchmark continues to keep legacy lanes so regressions can be compared.
+- **Quality:** the GNO/Qwen lane is the target higher-quality code retrieval path and is now preferred over the legacy `nomic-v1.5` baseline; the benchmark continues to keep legacy lanes so regressions can be compared.
 - **Speed:** the compact Qwen GGUF role is the smallest GNO lane and avoids making the balanced/quality generation models the default path. Real speed still depends on local `node-llama-cpp` hardware/runtime.
 - **Install size:** default use includes the `node-llama-cpp` runtime plus the cached Qwen GGUF embedding file. Codegraph still avoids test-time or smoke-benchmark downloads, and explicit legacy transformer aliases remain available for smaller embedding runs.
 - **Migration impact:** existing `.codegraphrc` files with `embeddings.model` such as `nomic-v1.5` continue to override the default embedding role. The `codegraph-default` preset remains available as a legacy compatibility preset.
@@ -57,4 +57,4 @@ Notes:
 - The Qwen/GGUF lane requires the bundled `node-llama-cpp` runtime and a cached GGUF model file for the `hf:` URI, or an explicitly allowed Codegraph GGUF cache download.
 - By default, use `CODEGRAPH_NO_AUTO_DOWNLOAD=1`, `HF_HUB_OFFLINE=1`, or omit `--allow-downloads` to avoid surprise downloads across lanes. To permit Codegraph GGUF model downloads intentionally, pass `--allow-downloads`.
 - The real benchmark currently creates separate document and query embedding ports for the same model so asymmetric input formatting is measured correctly. On GGUF/Qwen runs this can mean two wrappers for one model; plan memory/VRAM accordingly.
-- Issue #13 resolved the default decision in favor of GNO/Qwen compact defaults. Keep this benchmark as regression evidence and run with explicit download/cache policy.
+- Issue #13 resolved the default decision in favor of the GNO/Qwen local retrieval stack. Keep this benchmark as regression evidence and run with explicit download/cache policy.

--- a/docs/guides/retrieval-workflow.md
+++ b/docs/guides/retrieval-workflow.md
@@ -2,7 +2,7 @@
 
 This guide covers Codegraph's current retrieval workflow for semantic and hybrid search: model roles, embedding, cache policy, query expansion, reranking, stale-vector recovery, and migration from legacy config.
 
-Issue #13 decision: Codegraph now uses the GNO/Qwen compact defaults for all retrieval roles. The default preset is `gno-compact`, and the default embedding role is `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf`.
+Issue #13 decision: Codegraph now uses GNO’s local model stack for retrieval roles. The default preset is `slim-tuned`, and the default embedding role is `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf`.
 
 ## Quick workflow
 
@@ -29,17 +29,18 @@ Codegraph resolves retrieval models by role:
 
 Built-in presets are defined in `src/domain/search/models.ts`:
 
-- `gno-compact` — default compact local Qwen/GGUF embedding, rerank, expansion, and generation roles.
-- `codegraph-default` — legacy compatibility preset. It keeps the previous Codegraph embedding default (`nomic-v1.5`) and wires GNO-inspired retrieval roles for the optional stages.
-- `gno-balanced` — Qwen embedding/rerank with a larger expansion/generation role.
-- `gno-quality` — Qwen embedding/rerank with the largest built-in expansion/generation role.
+- `slim-tuned` — default GNO preset: Qwen embedding/rerank, fine-tuned expansion, and Qwen3 1.7B generation (~1GB).
+- `slim` — GNO slim preset: Qwen embedding/rerank with Qwen3 1.7B expansion and generation (~1GB).
+- `balanced` — GNO balanced preset: Qwen embedding/rerank with Qwen2.5 3B expansion and generation (~2GB).
+- `quality` — GNO quality preset: Qwen embedding/rerank with Qwen3 4B expansion and generation (~2.5GB).
+- `codegraph-default` — legacy compatibility preset. It keeps the previous Codegraph embedding default (`nomic-v1.5`) and wires GNO-style retrieval roles for the optional stages.
 
 Configure a preset and role overrides in `.codegraphrc.json`:
 
 ```json
 {
   "models": {
-    "preset": "gno-compact",
+    "preset": "slim-tuned",
     "roles": {
       "embed": "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf",
       "rerank": "https://reranker.example/v1/rerank"

--- a/scripts/retrieval-benchmark.ts
+++ b/scripts/retrieval-benchmark.ts
@@ -107,7 +107,7 @@ const DEFAULT_MODEL = 'nomic-v1.5';
 const CURRENT_DEFAULT_MODEL_URI = 'nomic-ai/nomic-embed-text-v1.5';
 const MINILM_MODEL_URI = 'Xenova/all-MiniLM-L6-v2';
 const JINA_CODE_MODEL_URI = 'Xenova/jina-embeddings-v2-base-code';
-const GNO_COMPACT_PRESET = 'gno-compact';
+const GNO_SLIM_TUNED_PRESET = 'slim-tuned';
 const GNO_QWEN_EMBED_URI = 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf';
 
 export const BENCHMARK_MODEL_PRESETS: BenchmarkModelPreset[] = [
@@ -130,11 +130,11 @@ export const BENCHMARK_MODEL_PRESETS: BenchmarkModelPreset[] = [
     notes: 'Existing code-focused transformer option.',
   },
   {
-    id: 'gno-qwen-compact',
-    label: 'GNO/Qwen compact preset embed role',
+    id: 'gno-qwen-slim-tuned',
+    label: 'GNO slim-tuned preset embed role',
     modelUri: GNO_QWEN_EMBED_URI,
-    rolePreset: GNO_COMPACT_PRESET,
-    notes: 'Qwen GGUF embedding path from the GNO-inspired preset registry.',
+    rolePreset: GNO_SLIM_TUNED_PRESET,
+    notes: 'Qwen GGUF embedding path from the GNO-aligned preset registry.',
   },
 ];
 

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -43,7 +43,7 @@ export const command: CommandDefinition = {
   options: [
     [
       '-m, --model <name>',
-      'Embedding model (default from config: GNO/Qwen compact GGUF). Run `codegraph models` for details',
+      'Embedding model (default from config: GNO slim-tuned / Qwen GGUF). Run `codegraph models` for details',
     ],
     [
       '-s, --strategy <name>',

--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -64,7 +64,7 @@ export const command: CommandDefinition = {
     }
 
     console.log('\nConfig:');
-    console.log('  .codegraphrc.json → { "models": { "preset": "gno-balanced" } }');
+    console.log('  .codegraphrc.json → { "models": { "preset": "balanced" } }');
     console.log('  codegraph embed [--model <alias-or-uri>] [--strategy <structured|source>]');
     console.log('  codegraph search "query" [--model <alias-or-uri>]\n');
   },

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -80,10 +80,19 @@ export const EMBEDDING_STRATEGIES: readonly string[] = ['structured', 'source'];
 
 export const GNO_COMPACT_EMBEDDING_MODEL =
   'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf';
+export const GNO_RERANK_MODEL =
+  'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf';
+export const GNO_SLIM_TUNED_EXPAND_MODEL =
+  'hf:guiltylemon/gno-expansion-slim-retrieval-v1/gno-expansion-auto-entity-lock-default-mix-lr95-f16.gguf';
+export const GNO_SLIM_MODEL = 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf';
+export const GNO_BALANCED_MODEL =
+  'hf:bartowski/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf';
+export const GNO_QUALITY_MODEL =
+  'hf:unsloth/Qwen3-4B-Instruct-2507-GGUF/Qwen3-4B-Instruct-2507-Q4_K_M.gguf';
 export const DEFAULT_EMBEDDING_MODEL = GNO_COMPACT_EMBEDDING_MODEL;
 export const LEGACY_TRANSFORMER_DEFAULT_MODEL = 'nomic-v1.5';
 export const DEFAULT_MODEL: string = DEFAULT_EMBEDDING_MODEL;
-export const DEFAULT_RETRIEVAL_PRESET = 'gno-compact';
+export const DEFAULT_RETRIEVAL_PRESET = 'slim-tuned';
 export const LEGACY_RETRIEVAL_PRESET = 'codegraph-default';
 
 export interface RetrievalModelPreset {
@@ -99,46 +108,62 @@ export interface ResolvedRetrievalModels {
 }
 
 export const RETRIEVAL_MODEL_PRESETS: Record<string, RetrievalModelPreset> = {
-  [LEGACY_RETRIEVAL_PRESET]: {
-    name: LEGACY_RETRIEVAL_PRESET,
-    desc: 'Legacy compatibility preset: previous Codegraph embedding model plus GNO-inspired retrieval roles.',
-    roles: {
-      embed: MODELS[LEGACY_TRANSFORMER_DEFAULT_MODEL]!.name,
-      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
-      expand: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
-      gen: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
-    },
-  },
   [DEFAULT_RETRIEVAL_PRESET]: {
     name: DEFAULT_RETRIEVAL_PRESET,
-    desc: 'Compact GNO-inspired local retrieval model roles.',
+    desc: 'GNO Slim Tuned (default, ~1GB): fine-tuned query expansion plus Qwen3 1.7B generation.',
     roles: {
       embed: GNO_COMPACT_EMBEDDING_MODEL,
-      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
-      expand: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
-      gen: 'hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf',
+      rerank: GNO_RERANK_MODEL,
+      expand: GNO_SLIM_TUNED_EXPAND_MODEL,
+      gen: GNO_SLIM_MODEL,
     },
   },
-  'gno-balanced': {
-    name: 'gno-balanced',
-    desc: 'Balanced GNO-inspired retrieval model roles.',
+  slim: {
+    name: 'slim',
+    desc: 'GNO Slim (~1GB): Qwen3 1.7B expansion and generation.',
     roles: {
       embed: GNO_COMPACT_EMBEDDING_MODEL,
-      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
-      expand: 'hf:bartowski/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf',
-      gen: 'hf:bartowski/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf',
+      rerank: GNO_RERANK_MODEL,
+      expand: GNO_SLIM_MODEL,
+      gen: GNO_SLIM_MODEL,
     },
   },
-  'gno-quality': {
-    name: 'gno-quality',
-    desc: 'Quality-oriented GNO-inspired retrieval model roles.',
+  balanced: {
+    name: 'balanced',
+    desc: 'GNO Balanced (~2GB): Qwen2.5 3B expansion and generation.',
     roles: {
       embed: GNO_COMPACT_EMBEDDING_MODEL,
-      rerank: 'hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf',
-      expand: 'hf:unsloth/Qwen3-4B-Instruct-2507-GGUF/Qwen3-4B-Instruct-2507-Q4_K_M.gguf',
-      gen: 'hf:unsloth/Qwen3-4B-Instruct-2507-GGUF/Qwen3-4B-Instruct-2507-Q4_K_M.gguf',
+      rerank: GNO_RERANK_MODEL,
+      expand: GNO_BALANCED_MODEL,
+      gen: GNO_BALANCED_MODEL,
     },
   },
+  quality: {
+    name: 'quality',
+    desc: 'GNO Quality (best answers, ~2.5GB): Qwen3 4B expansion and generation.',
+    roles: {
+      embed: GNO_COMPACT_EMBEDDING_MODEL,
+      rerank: GNO_RERANK_MODEL,
+      expand: GNO_QUALITY_MODEL,
+      gen: GNO_QUALITY_MODEL,
+    },
+  },
+  [LEGACY_RETRIEVAL_PRESET]: {
+    name: LEGACY_RETRIEVAL_PRESET,
+    desc: 'Legacy Codegraph preset: previous transformer embedding model with GNO-style optional roles.',
+    roles: {
+      embed: MODELS[LEGACY_TRANSFORMER_DEFAULT_MODEL]!.name,
+      rerank: GNO_RERANK_MODEL,
+      expand: GNO_SLIM_MODEL,
+      gen: GNO_SLIM_MODEL,
+    },
+  },
+};
+
+const RETRIEVAL_PRESET_ALIASES: Record<string, string> = {
+  'gno-compact': 'slim',
+  'gno-balanced': 'balanced',
+  'gno-quality': 'quality',
 };
 const NPM_BIN = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const BATCH_SIZE_MAP: Record<string, number> = {
@@ -175,9 +200,19 @@ export function getModelConfig(modelKey?: string): ModelConfig {
   return config;
 }
 
+const EXTERNAL_EMBEDDING_MODEL_CONFIGS: Record<string, ModelConfig> = {
+  [GNO_COMPACT_EMBEDDING_MODEL]: {
+    name: GNO_COMPACT_EMBEDDING_MODEL,
+    dim: 1024,
+    contextWindow: 32_768,
+    desc: 'Qwen3 embedding GGUF (~640MB). Multilingual/code retrieval, 32k context.',
+    quantized: true,
+  },
+};
+
 export function getEmbeddingModelConfig(modelKey?: string): ModelConfig {
   const key = resolveModelKey(modelKey);
-  const config = MODELS[key];
+  const config = MODELS[key] ?? EXTERNAL_EMBEDDING_MODEL_CONFIGS[key];
   if (config) return config;
   return {
     name: key,
@@ -197,15 +232,14 @@ function resolveConfiguredEmbeddingUri(config?: CodegraphConfig): string | undef
 
 export function resolveRetrievalModels(config?: CodegraphConfig): ResolvedRetrievalModels {
   const requestedPreset = config?.models?.preset || DEFAULT_RETRIEVAL_PRESET;
+  const resolvedPreset = RETRIEVAL_PRESET_ALIASES[requestedPreset] ?? requestedPreset;
   const preset =
-    RETRIEVAL_MODEL_PRESETS[requestedPreset] ?? RETRIEVAL_MODEL_PRESETS[DEFAULT_RETRIEVAL_PRESET]!;
+    RETRIEVAL_MODEL_PRESETS[resolvedPreset] ?? RETRIEVAL_MODEL_PRESETS[DEFAULT_RETRIEVAL_PRESET]!;
   const roles: ModelRoleMap = { ...preset.roles };
   const overrides = config?.models?.roles;
 
   const selectedBuiltInPresetWithOwnEmbedding =
-    requestedPreset !== DEFAULT_RETRIEVAL_PRESET &&
-    requestedPreset !== LEGACY_RETRIEVAL_PRESET &&
-    preset.name === requestedPreset;
+    preset.name !== DEFAULT_RETRIEVAL_PRESET && preset.name !== LEGACY_RETRIEVAL_PRESET;
   const configuredEmbed = selectedBuiltInPresetWithOwnEmbedding
     ? undefined
     : resolveConfiguredEmbeddingUri(config);
@@ -223,7 +257,7 @@ export function resolveRetrievalModels(config?: CodegraphConfig): ResolvedRetrie
 
   return {
     preset: preset.name,
-    requestedPreset: requestedPreset === preset.name ? undefined : requestedPreset,
+    requestedPreset: RETRIEVAL_MODEL_PRESETS[resolvedPreset] ? undefined : requestedPreset,
     roles,
   };
 }

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -35,7 +35,7 @@ export const DEFAULTS = {
     llmProvider: null as string | null,
   },
   models: {
-    preset: 'gno-compact',
+    preset: 'slim-tuned',
     roles: {} as Partial<Record<'embed' | 'rerank' | 'expand' | 'gen', string>>,
   },
   llm: {

--- a/tests/benchmarks/retrieval-benchmark.test.ts
+++ b/tests/benchmarks/retrieval-benchmark.test.ts
@@ -34,7 +34,7 @@ describe('retrieval benchmark harness', () => {
       'current-default',
       'minilm-baseline',
       'jina-code',
-      'gno-qwen-compact',
+      'gno-qwen-slim-tuned',
     ]);
     expect(output.mode).toBe('mock');
     expect(output.queries).toHaveLength(4);

--- a/tests/search/embed-command.test.ts
+++ b/tests/search/embed-command.test.ts
@@ -39,17 +39,17 @@ describe('embed command model compatibility', () => {
   });
 
   test('routes implicit supported Qwen GGUF preset embed URI through buildEmbeddings', async () => {
-    const config = ctx({ models: { preset: 'gno-compact' } });
+    const config = ctx({ models: { preset: 'slim' } });
 
     expect(resolveModelRoleUri(config.config, 'embed')).toBe(
-      RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed,
+      RETRIEVAL_MODEL_PRESETS.slim!.roles.embed,
     );
 
     await command.execute?.(['.'], { strategy: 'structured' }, config);
 
     expect(buildEmbeddingsMock).toHaveBeenCalledWith(
       expect.any(String),
-      RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed,
+      RETRIEVAL_MODEL_PRESETS.slim!.roles.embed,
       undefined,
       { strategy: 'structured' },
     );
@@ -73,7 +73,7 @@ describe('embed command model compatibility', () => {
         strategy: 'structured',
         model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
       },
-      ctx({ models: { preset: 'gno-compact' } }),
+      ctx({ models: { preset: 'slim' } }),
     );
 
     expect(buildEmbeddingsMock).toHaveBeenCalledWith(

--- a/tests/search/model-presets.test.ts
+++ b/tests/search/model-presets.test.ts
@@ -9,6 +9,7 @@ import {
   resolveModelRoleUri,
   resolveRetrievalModels,
 } from '../../src/domain/search/index.js';
+import { getEmbeddingModelConfig } from '../../src/domain/search/models.js';
 import { DEFAULTS } from '../../src/infrastructure/config.js';
 import type { CodegraphConfig } from '../../src/types.js';
 
@@ -22,16 +23,18 @@ function config(overrides: Partial<CodegraphConfig> = {}): CodegraphConfig {
 }
 
 describe('retrieval model role resolution', () => {
-  test('resolves every role from the GNO compact default preset', () => {
+  test('resolves every role from GNO slim-tuned as the default preset', () => {
     const resolved = resolveRetrievalModels(config());
 
-    expect(DEFAULT_RETRIEVAL_PRESET).toBe('gno-compact');
+    expect(DEFAULT_RETRIEVAL_PRESET).toBe('slim-tuned');
     expect(DEFAULT_MODEL).toBe(DEFAULT_EMBEDDING_MODEL);
-    expect(resolved.preset).toBe('gno-compact');
+    expect(resolved.preset).toBe('slim-tuned');
     expect(resolved.roles.embed).toBe(DEFAULT_EMBEDDING_MODEL);
     expect(resolved.roles.rerank).toContain('Reranker');
-    expect(resolved.roles.expand).toContain('Qwen');
-    expect(resolved.roles.gen).toContain('Qwen');
+    expect(resolved.roles.expand).toBe(
+      'hf:guiltylemon/gno-expansion-slim-retrieval-v1/gno-expansion-auto-entity-lock-default-mix-lr95-f16.gguf',
+    );
+    expect(resolved.roles.gen).toBe('hf:unsloth/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf');
   });
 
   test('keeps codegraph-default available as a legacy compatibility preset', () => {
@@ -62,11 +65,11 @@ describe('retrieval model role resolution', () => {
     const resolved = resolveRetrievalModels({
       ...(DEFAULTS as CodegraphConfig),
       embeddings: { ...DEFAULTS.embeddings },
-      models: { ...DEFAULTS.models, preset: 'gno-balanced' },
+      models: { ...DEFAULTS.models, preset: 'balanced' },
     });
 
-    expect(resolved.preset).toBe('gno-balanced');
-    expect(resolved.roles.embed).toBe(RETRIEVAL_MODEL_PRESETS['gno-balanced']!.roles.embed);
+    expect(resolved.preset).toBe('balanced');
+    expect(resolved.roles.embed).toBe(RETRIEVAL_MODEL_PRESETS.balanced!.roles.embed);
     expect(resolved.roles.embed).not.toBe(MODELS[LEGACY_TRANSFORMER_DEFAULT_MODEL]!.name);
   });
 
@@ -74,7 +77,7 @@ describe('retrieval model role resolution', () => {
     const resolved = resolveRetrievalModels(
       config({
         models: {
-          preset: 'gno-compact',
+          preset: 'slim-tuned',
           roles: {
             embed: 'hf:custom/embed-model',
             rerank: 'http://localhost:8080/rerank',
@@ -83,7 +86,7 @@ describe('retrieval model role resolution', () => {
       }),
     );
 
-    expect(resolved.preset).toBe('gno-compact');
+    expect(resolved.preset).toBe('slim-tuned');
     expect(resolved.roles.embed).toBe('hf:custom/embed-model');
     expect(resolved.roles.rerank).toBe('http://localhost:8080/rerank');
     expect(resolved.roles.expand).toBeTruthy();
@@ -96,6 +99,25 @@ describe('retrieval model role resolution', () => {
     expect(resolved.preset).toBe(DEFAULT_RETRIEVAL_PRESET);
     expect(resolved.requestedPreset).toBe('not-real');
     expect(resolved.roles.embed).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  test('keeps old gno-prefixed preset names as compatibility aliases', () => {
+    expect(resolveRetrievalModels(config({ models: { preset: 'gno-compact' } })).preset).toBe(
+      'slim',
+    );
+    expect(resolveRetrievalModels(config({ models: { preset: 'gno-balanced' } })).preset).toBe(
+      'balanced',
+    );
+    expect(resolveRetrievalModels(config({ models: { preset: 'gno-quality' } })).preset).toBe(
+      'quality',
+    );
+  });
+
+  test('uses the Qwen embedding model card context window for GGUF embeddings', () => {
+    const config = getEmbeddingModelConfig(DEFAULT_EMBEDDING_MODEL);
+
+    expect(config.dim).toBe(1024);
+    expect(config.contextWindow).toBe(32_768);
   });
 
   test('explicit legacy embeddings.model overrides the default embed role compatibility layer', () => {

--- a/tests/search/models-command.test.ts
+++ b/tests/search/models-command.test.ts
@@ -34,19 +34,22 @@ describe('models command defaults', () => {
     const output = runModelsCommand();
 
     // Preset line
-    expect(output).toContain('Preset: gno-compact');
+    expect(output).toContain('Preset: slim-tuned');
 
     // Roles — short form
     expect(output).toContain('embed    Qwen/Qwen3-Embedding-0.6B-Q8_0.gguf');
     expect(output).toContain('rerank   ggml-org/qwen3-reranker-0.6b-q8_0.gguf');
-    expect(output).toContain('expand   unsloth/Qwen3-1.7B-Q4_K_M.gguf');
+    expect(output).toContain(
+      'expand   guiltylemon/gno-expansion-auto-entity-lock-default-mix-lr95-f16.gguf',
+    );
     expect(output).toContain('gen      unsloth/Qwen3-1.7B-Q4_K_M.gguf');
 
     // Presets section
     expect(output).toContain('Presets:');
-    expect(output).toMatch(/gno-compact\s+.*←/);
-    expect(output).toContain('gno-balanced');
-    expect(output).toContain('gno-quality');
+    expect(output).toMatch(/slim-tuned\s+.*←/);
+    expect(output).toContain('slim');
+    expect(output).toContain('balanced');
+    expect(output).toContain('quality');
 
     // Legacy aliases come last
     expect(output).toContain('Embedding aliases (--model):');
@@ -57,10 +60,10 @@ describe('models command defaults', () => {
   test('shows resolved preset when config overrides it', () => {
     const output = runModelsCommand({
       embeddings: { model: 'minilm', llmProvider: null },
-      models: { preset: 'gno-balanced' },
+      models: { preset: 'balanced' },
     });
 
-    expect(output).toContain('Preset: gno-balanced');
+    expect(output).toContain('Preset: balanced');
     expect(output).toContain('embed    Qwen/Qwen3-Embedding-0.6B-Q8_0.gguf');
     expect(output).not.toMatch(/minilm.*←/);
   });

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -59,7 +59,7 @@ describe('Qwen embedding compatibility formatting', () => {
 
 describe('model URI parsing, GGUF validation, and download policy', () => {
   test('built-in GNO-inspired preset role URIs use explicit GGUF filenames', () => {
-    for (const presetName of ['gno-compact', 'gno-balanced', 'gno-quality'] as const) {
+    for (const presetName of ['slim-tuned', 'slim', 'balanced', 'quality'] as const) {
       const preset = RETRIEVAL_MODEL_PRESETS[presetName]!;
       for (const uri of Object.values(preset.roles)) {
         expect(uri).toMatch(/^hf:.+\.gguf$/);
@@ -277,12 +277,12 @@ describe('embedding port factory', () => {
     }
   });
 
-  test('creates the built-in GNO compact Qwen embed preset through the GGUF cache path', async () => {
+  test('creates the built-in GNO slim Qwen embed preset through the GGUF cache path', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-preset-cache-'));
     try {
-      const uri = resolveModelRoleUri({ models: { preset: 'gno-compact' } }, 'embed');
+      const uri = resolveModelRoleUri({ models: { preset: 'slim' } }, 'embed');
       expect(uri).toBe('hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf');
-      expect(uri).toBe(RETRIEVAL_MODEL_PRESETS['gno-compact']!.roles.embed);
+      expect(uri).toBe(RETRIEVAL_MODEL_PRESETS.slim!.roles.embed);
 
       const file = ggufFile(tmp, 'Qwen3-Embedding-0.6B-Q8_0.gguf');
       fs.writeFileSync(

--- a/tests/search/search-command.test.ts
+++ b/tests/search/search-command.test.ts
@@ -17,7 +17,7 @@ const { command } = await import('../../src/cli/commands/search.js');
 
 function ctx(): CliContext {
   return {
-    config: { models: { preset: 'gno-compact' } },
+    config: { models: { preset: 'slim-tuned' } },
     resolveNoTests: () => false,
     resolveQueryOpts: (opts) => opts,
     formatSize: (bytes) => `${bytes}B`,

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -62,7 +62,7 @@ describe('DEFAULTS', () => {
       model: 'hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf',
       llmProvider: null,
     });
-    expect(DEFAULTS.models.preset).toBe('gno-compact');
+    expect(DEFAULTS.models.preset).toBe('slim-tuned');
   });
 
   it('has llm defaults', () => {


### PR DESCRIPTION
## Summary
- align built-in retrieval preset names with GNO: `slim-tuned`, `slim`, `balanced`, `quality`
- make `slim-tuned` the default and add GNO's fine-tuned expansion model
- register Qwen3-Embedding-0.6B GGUF as a known embedding model with 1024 dimensions and 32k context
- keep old `gno-compact`, `gno-balanced`, and `gno-quality` names as compatibility aliases
- update `codegraph models`, docs, config defaults, benchmark metadata, and tests

## Verification
- `npx vitest run tests/search/model-presets.test.ts tests/search/models-command.test.ts tests/search/embed-command.test.ts tests/search/qwen-embedding-ports.test.ts tests/search/search-command.test.ts tests/search/embedding-strategy.test.ts tests/unit/config.test.ts tests/benchmarks/retrieval-benchmark.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm audit` reports 0 vulnerabilities
- `node dist/cli.js build`
- `node dist/cli.js diff-impact --staged -T`
- inspected `node dist/cli.js models` outside repo config: default shows `Preset: slim-tuned`
- verified built `getEmbeddingModelConfig(DEFAULT_EMBEDDING_MODEL)` reports `dim: 1024`, `contextWindow: 32768`

## Note
`npm test` currently fails in `tests/integration/check.test.ts` on two `checkData(..., { staged: true })` expectations (`cycles` predicate missing). Those failures also reproduce when this patch is unstaged and appear unrelated to the preset/context-window change. The retrieval benchmark failure from the preset ID rename was fixed in this PR.