### PR TITLE
fix(search): clamp GGUF embeddings with tokenizer

### DIFF
--- a/src/domain/search/embedding-factory.ts
+++ b/src/domain/search/embedding-factory.ts
@@ -44,6 +44,9 @@ type LlamaEmbeddingContext = {
   getEmbeddingFor(text: string): Promise<{ vector: Iterable<number> }>;
 };
 type LlamaEmbeddingModel = {
+  trainContextSize?: number;
+  tokenize?: (text: string) => readonly unknown[];
+  detokenize?: (tokens: readonly unknown[]) => string;
   createEmbeddingContext(): Promise<LlamaEmbeddingContext>;
   dispose?: () => Promise<void> | void;
 };
@@ -79,7 +82,7 @@ class NodeLlamaCppEmbeddingPort implements EmbeddingPort {
     const context = await this.getContext();
     const vectors: Float32Array[] = [];
     for (const text of texts) {
-      const embedding = await context.getEmbeddingFor(text);
+      const embedding = await context.getEmbeddingFor(this.clampToModelContext(text));
       vectors.push(new Float32Array(Array.from(embedding.vector)));
     }
     return vectors;
@@ -89,6 +92,27 @@ class NodeLlamaCppEmbeddingPort implements EmbeddingPort {
     await this.model?.dispose?.();
     this.model = undefined;
     this.context = undefined;
+  }
+
+  private clampToModelContext(text: string): string {
+    const model = this.model;
+    const rawLimit = model?.trainContextSize;
+    const tokenize = model?.tokenize;
+    const detokenize = model?.detokenize;
+    if (
+      typeof rawLimit !== 'number' ||
+      !Number.isFinite(rawLimit) ||
+      rawLimit <= 0 ||
+      !tokenize ||
+      !detokenize
+    ) {
+      return text;
+    }
+
+    const limit = Math.max(1, Math.floor(rawLimit) - 4);
+    const tokens = tokenize(text);
+    if (tokens.length <= limit) return text;
+    return detokenize(tokens.slice(0, limit));
   }
 
   private async getContext(): Promise<{

--- a/tests/search/qwen-embedding-ports.test.ts
+++ b/tests/search/qwen-embedding-ports.test.ts
@@ -314,6 +314,38 @@ describe('embedding port factory', () => {
     }
   });
 
+  test('clamps Qwen GGUF inputs to the runtime tokenizer context window', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-gguf-clamp-'));
+    try {
+      const file = ggufFile(tmp, 'Qwen3-Embedding.gguf');
+      const embeddedTexts: string[] = [];
+      const runtimeLoader = vi.fn(async () => ({
+        getLlama: async () => ({
+          loadModel: async () => ({
+            trainContextSize: 6,
+            tokenize: (text: string) => text.split(''),
+            detokenize: (tokens: readonly string[]) => tokens.join(''),
+            createEmbeddingContext: async () => ({
+              getEmbeddingFor: async (text: string) => {
+                embeddedTexts.push(text);
+                if (text.length > 2) throw new Error('context overflow');
+                return { vector: [text.length] };
+              },
+            }),
+          }),
+        }),
+      }));
+
+      const port = await createEmbeddingPort(`file:${file}`, { inputType: 'raw', runtimeLoader });
+      const [vector] = await port.embedBatch(['abcdefghi']);
+
+      expect(Array.from(vector!)).toEqual([2]);
+      expect(embeddedTexts).toEqual(['ab']);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('creates Qwen GGUF port from local file without requiring node-llama-cpp until used', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-factory-'));
     try {


### PR DESCRIPTION
## Summary
- clamp GGUF embedding inputs with the node-llama-cpp tokenizer and model `trainContextSize` before inference
- avoids recovery repeatedly resetting/reloading node-llama-cpp when a symbol is still too large after rough char-based truncation
- adds a regression test for tokenizer-based clamping

## Verification
- `npx vitest run tests/search/qwen-embedding-ports.test.ts tests/search/embedding-port.test.ts tests/search/embedding-strategy.test.ts tests/search/model-presets.test.ts tests/search/embed-command.test.ts tests/search/search-command.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `node dist/cli.js build`
- `node dist/cli.js diff-impact --staged -T`